### PR TITLE
Refactor image builder workflow and update dependencies

### DIFF
--- a/.github/workflows/dockerfile-image-builder.yaml
+++ b/.github/workflows/dockerfile-image-builder.yaml
@@ -2,9 +2,9 @@
 name: Build and Publish Container Images
 on:
   workflow_dispatch:
+  pull_request:
   push:
-    branches:
-      - main
+    branches: [main]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/warpgate-image-builder.yaml
+++ b/.github/workflows/warpgate-image-builder.yaml
@@ -98,9 +98,3 @@ jobs:
             -b "${{ matrix.blueprint }}" \
             -p "$HOME/cowdogmoo/ansible-collection-workstation" \
             -t "${{ secrets.BOT_TOKEN }}"
-
-      - name: Setup tmate session
-        if: ${{ failure() }}
-        uses: mxschmitt/action-tmate@v3
-        with:
-          limit-access-to-actor: true

--- a/.github/workflows/warpgate-image-builder.yaml
+++ b/.github/workflows/warpgate-image-builder.yaml
@@ -14,6 +14,7 @@ env:
   PRODUCT_VERSION: "latest"
   IMAGE_NAME: ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}
   RUNZERO_DOWNLOAD_TOKEN: ${{ secrets.RUNZERO_DOWNLOAD_TOKEN }}
+  GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }} # Used for image builder to push to ghcr.io
 
 jobs:
   generate-blueprints:
@@ -60,7 +61,7 @@ jobs:
         with:
           registry: ghcr.io
           username: "${{ github.repository_owner }}"
-          password: "${{ secrets.BOT_TOKEN }}"
+          password: "${{ secrets.GITHUB_TOKEN }}"
 
       - name: Set up Go
         uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5
@@ -88,16 +89,16 @@ jobs:
       - name: Make repository name lowercase
         id: lower-repo
         run: |
-          echo "repo_owner_lowercase=$(echo '${{ github.repository_owner }}' | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
+          echo "repo_owner_lowercase=$(echo '${{ github.repository_owner }}' \
+          | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
 
       - name: Run image builder for each blueprint
         run: |
-          export RUNZERO_DOWNLOAD_TOKEN="${{ secrets.RUNZERO_DOWNLOAD_TOKEN }}"
           # Run the wg imageBuilder command with the correct paths for the current matrix blueprint.
           wg imageBuilder \
             -b "${{ matrix.blueprint }}" \
             -p "$HOME/cowdogmoo/ansible-collection-workstation" \
-            -t "${{ secrets.BOT_TOKEN }}"
+            -t "${{ secrets.GITHUB_TOKEN }}"
 
       - name: Setup tmate session
         if: ${{ failure() }}

--- a/.github/workflows/warpgate-image-builder.yaml
+++ b/.github/workflows/warpgate-image-builder.yaml
@@ -2,9 +2,9 @@
 name: Warpgate Image Builder
 on:
   workflow_dispatch:
+  pull_request:
   push:
-    branches:
-      - main
+    branches: [main]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/warpgate-image-builder.yaml
+++ b/.github/workflows/warpgate-image-builder.yaml
@@ -14,7 +14,6 @@ env:
   PRODUCT_VERSION: "latest"
   IMAGE_NAME: ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}
   RUNZERO_DOWNLOAD_TOKEN: ${{ secrets.RUNZERO_DOWNLOAD_TOKEN }}
-  GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }} # Used for image builder to push to ghcr.io
 
 jobs:
   generate-blueprints:
@@ -61,7 +60,7 @@ jobs:
         with:
           registry: ghcr.io
           username: "${{ github.repository_owner }}"
-          password: "${{ secrets.GITHUB_TOKEN }}"
+          password: "${{ secrets.BOT_TOKEN }}"
 
       - name: Set up Go
         uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5
@@ -89,16 +88,16 @@ jobs:
       - name: Make repository name lowercase
         id: lower-repo
         run: |
-          echo "repo_owner_lowercase=$(echo '${{ github.repository_owner }}' \
-          | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
+          echo "repo_owner_lowercase=$(echo '${{ github.repository_owner }}' | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
 
       - name: Run image builder for each blueprint
         run: |
+          export RUNZERO_DOWNLOAD_TOKEN="${{ secrets.RUNZERO_DOWNLOAD_TOKEN }}"
           # Run the wg imageBuilder command with the correct paths for the current matrix blueprint.
           wg imageBuilder \
             -b "${{ matrix.blueprint }}" \
             -p "$HOME/cowdogmoo/ansible-collection-workstation" \
-            -t "${{ secrets.GITHUB_TOKEN }}"
+            -t "${{ secrets.BOT_TOKEN }}"
 
       - name: Setup tmate session
         if: ${{ failure() }}

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,4 +1,3 @@
-# User: l
 golang 1.22.0
 python 3.12.2
 ruby 3.2.2

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,4 @@
+# User: l
 golang 1.22.0
 python 3.12.2
 ruby 3.2.2

--- a/blueprints/runzero-explorer/config.yaml
+++ b/blueprints/runzero-explorer/config.yaml
@@ -6,7 +6,7 @@ packer_templates:
   - name: runzero-explorer.pkr.hcl
     base:
       name: ubuntu
-      version: latest
+      version: noble
     tag:
       name: cowdogmoo/runzero-explorer
       version: latest

--- a/blueprints/runzero-explorer/config.yaml
+++ b/blueprints/runzero-explorer/config.yaml
@@ -6,7 +6,7 @@ packer_templates:
   - name: runzero-explorer.pkr.hcl
     base:
       name: ubuntu
-      version: noble
+      version: latest
     tag:
       name: cowdogmoo/runzero-explorer
       version: latest

--- a/blueprints/runzero-explorer/config.yaml
+++ b/blueprints/runzero-explorer/config.yaml
@@ -6,7 +6,7 @@ packer_templates:
   - name: runzero-explorer.pkr.hcl
     base:
       name: ubuntu
-      version: 24.04
+      version: latest
     tag:
       name: cowdogmoo/runzero-explorer
       version: latest

--- a/blueprints/runzero-explorer/config.yaml
+++ b/blueprints/runzero-explorer/config.yaml
@@ -6,7 +6,7 @@ packer_templates:
   - name: runzero-explorer.pkr.hcl
     base:
       name: ubuntu
-      version: latest
+      version: 24.04
     tag:
       name: cowdogmoo/runzero-explorer
       version: latest

--- a/blueprints/runzero-explorer/packer_templates/plugins.pkr.hcl
+++ b/blueprints/runzero-explorer/packer_templates/plugins.pkr.hcl
@@ -2,7 +2,7 @@
 packer {
   required_plugins {
     docker = {
-      version = ">= 1.0.1"
+      version = ">= 1.0.9"
       source  = "github.com/hashicorp/docker"
     }
   }

--- a/blueprints/runzero-explorer/packer_templates/runzero-explorer.pkr.hcl
+++ b/blueprints/runzero-explorer/packer_templates/runzero-explorer.pkr.hcl
@@ -59,14 +59,14 @@ build {
     destination = "${var.pkr_build_dir}/provision.sh"
   }
 
-#   provisioner "shell" {
-#     environment_vars = [
-#       "PKR_BUILD_DIR=${var.pkr_build_dir}",
-#       "RUNZERO_DOWNLOAD_TOKEN=${var.runzero_download_token}",
-#     ]
-#     inline = [
-#       "chmod +x ${var.pkr_build_dir}/provision.sh",
-#       "${var.pkr_build_dir}/provision.sh"
-#     ]
-#   }
+  provisioner "shell" {
+    environment_vars = [
+      "PKR_BUILD_DIR=${var.pkr_build_dir}",
+      "RUNZERO_DOWNLOAD_TOKEN=${var.runzero_download_token}",
+    ]
+    inline = [
+      "chmod +x ${var.pkr_build_dir}/provision.sh",
+      "${var.pkr_build_dir}/provision.sh"
+    ]
+  }
 }

--- a/blueprints/runzero-explorer/packer_templates/runzero-explorer.pkr.hcl
+++ b/blueprints/runzero-explorer/packer_templates/runzero-explorer.pkr.hcl
@@ -63,7 +63,6 @@ build {
     environment_vars = [
       "PKR_BUILD_DIR=${var.pkr_build_dir}",
       "RUNZERO_DOWNLOAD_TOKEN=${var.runzero_download_token}",
-      "DEBIAN_FRONTEND=noninteractive",
     ]
     inline = [
       "chmod +x ${var.pkr_build_dir}/provision.sh",

--- a/blueprints/runzero-explorer/packer_templates/runzero-explorer.pkr.hcl
+++ b/blueprints/runzero-explorer/packer_templates/runzero-explorer.pkr.hcl
@@ -63,6 +63,7 @@ build {
     environment_vars = [
       "PKR_BUILD_DIR=${var.pkr_build_dir}",
       "RUNZERO_DOWNLOAD_TOKEN=${var.runzero_download_token}",
+      "DEBIAN_FRONTEND=noninteractive",
     ]
     inline = [
       "chmod +x ${var.pkr_build_dir}/provision.sh",

--- a/blueprints/runzero-explorer/packer_templates/runzero-explorer.pkr.hcl
+++ b/blueprints/runzero-explorer/packer_templates/runzero-explorer.pkr.hcl
@@ -9,7 +9,7 @@
 #########################################################################################
 source "docker" "runzero_amd64" {
   commit     = true
-  image      = "${var.base_image}:${var.base_image_version}"
+  image      = "ubuntu:latest"
   platform   = "linux/amd64"
   privileged = true
 
@@ -18,7 +18,6 @@ source "docker" "runzero_amd64" {
   }
 
   changes = [
-    "ENTRYPOINT ${var.entrypoint}",
     "USER ${var.container_user}",
     "WORKDIR ${var.workdir}",
     "LABEL architecture=amd64"
@@ -29,7 +28,7 @@ source "docker" "runzero_amd64" {
 
 source "docker" "runzero_arm64" {
   commit     = true
-  image      = "${var.base_image}:${var.base_image_version}"
+  image      = "ubuntu:latest"
   platform   = "linux/arm64"
   privileged = true
 
@@ -38,7 +37,6 @@ source "docker" "runzero_arm64" {
   }
 
   changes = [
-    "ENTRYPOINT ${var.entrypoint}",
     "USER ${var.container_user}",
     "WORKDIR ${var.workdir}",
     "LABEL architecture=arm64"
@@ -63,35 +61,22 @@ build {
     destination = "${var.pkr_build_dir}/provision.sh"
   }
 
-  provisioner "shell" {
-    environment_vars = [
-      "PKR_BUILD_DIR=${var.pkr_build_dir}",
-      "RUNZERO_DOWNLOAD_TOKEN=${var.runzero_download_token}",
-    ]
-    inline = [
-      "chmod +x ${var.pkr_build_dir}/provision.sh",
-      "${var.pkr_build_dir}/provision.sh"
-    ]
+  post-processor "docker-tag" {
+    repository = "ghcr.io/cowdogmoo/runzero-explorer"
+    tags       = ["amd64-latest"]
+    only       = ["source.docker.runzero_amd64"]
   }
 
-  post-processors {
-    post-processor "docker-tag" {
-      repository = "${var.registry_server}/${var.image_name}"
-      tags       = ["amd64-latest"]
-      only       = ["source.docker.runzero_amd64"]
-    }
+  post-processor "docker-tag" {
+    repository = "ghcr.io/cowdogmoo/runzero-explorer"
+    tags       = ["arm64-latest"]
+    only       = ["source.docker.runzero_arm64"]
+  }
 
-    post-processor "docker-tag" {
-      repository = "${var.registry_server}/${var.image_name}"
-      tags       = ["arm64-latest"]
-      only       = ["source.docker.runzero_arm64"]
-    }
-
-    post-processor "docker-push" {
-      login          = true
-      login_server   = "${var.registry_server}"
-      login_username = "${var.registry_username}"
-      login_password = "${var.registry_cred}"
-    }
+  post-processor "docker-push" {
+    login          = true
+    login_server   = "ghcr.io"
+    login_username = "cowdogmoo"
+    login_password = "${var.registry_cred}"
   }
 }

--- a/blueprints/runzero-explorer/packer_templates/runzero-explorer.pkr.hcl
+++ b/blueprints/runzero-explorer/packer_templates/runzero-explorer.pkr.hcl
@@ -1,7 +1,7 @@
 #########################################################################################
-# runzero packer template
+# runZero packer template
 #
-# Author: Jayson Grace <Jayson Grace <jayson.e.grace@gmail.com>
+# Author: Jayson Grace <jayson.e.grace@gmail.com>
 #
 # Description: Create a docker image provisioned with
 # https://github.com/CowDogMoo/ansible-collection-workstation/tree/main/playbooks/runzero

--- a/blueprints/runzero-explorer/packer_templates/runzero-explorer.pkr.hcl
+++ b/blueprints/runzero-explorer/packer_templates/runzero-explorer.pkr.hcl
@@ -1,7 +1,7 @@
 #########################################################################################
-# runZero packer template
+# runzero packer template
 #
-# Author: Jayson Grace <jayson.e.grace@gmail.com>
+# Author: Jayson Grace <Jayson Grace <jayson.e.grace@gmail.com>
 #
 # Description: Create a docker image provisioned with
 # https://github.com/CowDogMoo/ansible-collection-workstation/tree/main/playbooks/runzero

--- a/blueprints/runzero-explorer/packer_templates/variables.pkr.hcl
+++ b/blueprints/runzero-explorer/packer_templates/variables.pkr.hcl
@@ -1,13 +1,11 @@
 variable "base_image" {
   type        = string
   description = "Base image."
-  default     = "ubuntu"
 }
 
 variable "base_image_version" {
   type        = string
   description = "Version of the base image."
-  default     = "noble"
 }
 
 variable "blueprint_name" {

--- a/blueprints/runzero-explorer/packer_templates/variables.pkr.hcl
+++ b/blueprints/runzero-explorer/packer_templates/variables.pkr.hcl
@@ -7,7 +7,7 @@ variable "base_image" {
 variable "base_image_version" {
   type        = string
   description = "Version of the base image."
-  default     = "latest"
+  default     = "noble"
 }
 
 variable "blueprint_name" {

--- a/blueprints/runzero-explorer/packer_templates/variables.pkr.hcl
+++ b/blueprints/runzero-explorer/packer_templates/variables.pkr.hcl
@@ -1,72 +1,40 @@
 variable "base_image" {
-  type    = string
+  type        = string
   description = "Base image."
-  default = "ubuntu"
+  default     = "ubuntu"
 }
 
 variable "base_image_version" {
-  type    = string
+  type        = string
   description = "Version of the base image."
-  default = "noble"
+  default     = "noble"
 }
 
 variable "blueprint_name" {
-  type    = string
+  type        = string
   description = "Name of the blueprint."
 }
 
 variable "container_user" {
-  type    = string
+  type        = string
   description = "Default user for a new container."
 }
 
-variable "new_image_tag" {
-  type    = string
-  description = "Tag for the created image."
-}
-
-variable "new_image_version" {
-  type = string
-  description = "Version for the created image."
-}
-
 variable "pkr_build_dir" {
-  type    = string
+  type        = string
   description = "Directory that packer will execute the transferred provisioning logic from within the container."
-  default = "/ansible-collection-workstation"
+  default     = "/ansible-collection-workstation"
 }
 
 variable "provision_repo_path" {
-  type    = string
+  type        = string
   description = "Path on disk to the repo that contains the provisioning code to build the container image."
 }
 
-variable "registry_server" {
-  type    = string
-  description = "Container registry to push to."
-}
-
-variable "registry_username" {
-  type    = string
-  description = "Username to connect to registry with."
-}
-
-variable "registry_cred" {
-  type    = string
-  description = "Token or credential to authenticate to registry with."
-  default = env("GITHUB_TOKEN")
-  validation {
-    condition     = length(var.registry_cred) > 0
-    error_message = <<EOF
-The GITHUB_TOKEN is not set: this is required to push the container image.
-EOF
-  }
-}
-
 variable "runzero_download_token" {
-  type    = string
+  type        = string
   description = "Token to download runzero."
-  default = env("RUNZERO_DOWNLOAD_TOKEN")
+  default     = env("RUNZERO_DOWNLOAD_TOKEN")
   validation {
     condition     = length(var.runzero_download_token) > 0
     error_message = <<EOF
@@ -76,12 +44,12 @@ EOF
 }
 
 variable "setup_systemd" {
-  type    = bool
+  type        = bool
   description = "Create systemd service for container."
-  default = false
+  default     = false
 }
 
 variable "workdir" {
-  type    = string
+  type        = string
   description = "Working directory for a new container."
 }

--- a/blueprints/runzero-explorer/packer_templates/variables.pkr.hcl
+++ b/blueprints/runzero-explorer/packer_templates/variables.pkr.hcl
@@ -7,7 +7,7 @@ variable "base_image" {
 variable "base_image_version" {
   type        = string
   description = "Version of the base image."
-  default     = "noble"
+  default     = "latest"
 }
 
 variable "blueprint_name" {

--- a/blueprints/runzero-explorer/packer_templates/variables.pkr.hcl
+++ b/blueprints/runzero-explorer/packer_templates/variables.pkr.hcl
@@ -18,11 +18,6 @@ variable "container_user" {
   description = "Default user for a new container."
 }
 
-variable "entrypoint" {
-  type    = string
-  description = "Optional entrypoint script."
-}
-
 variable "new_image_tag" {
   type    = string
   description = "Tag for the created image."
@@ -57,6 +52,13 @@ variable "registry_username" {
 variable "registry_cred" {
   type    = string
   description = "Token or credential to authenticate to registry with."
+  default = env("GITHUB_TOKEN")
+  validation {
+    condition     = length(var.registry_cred) > 0
+    error_message = <<EOF
+The GITHUB_TOKEN is not set: this is required to push the container image.
+EOF
+  }
 }
 
 variable "runzero_download_token" {

--- a/blueprints/runzero-explorer/scripts/provision.sh
+++ b/blueprints/runzero-explorer/scripts/provision.sh
@@ -9,14 +9,19 @@ export CLEANUP="${2:-true}"
 # Necessary for ansible to work properly
 export TERM=xterm-256color
 
+# Set this only if on a debian-based system
+if [[ -f /etc/debian_version ]]; then
+    export DEBIAN_FRONTEND=noninteractive
+fi
+
 install_dependencies() {
-    # Get latest packages and install aptitude
-    apt-get update -y 2> /dev/null | grep packages | cut -d '.' -f 1
+    # Get latest packages
+    apt update -y 2> /dev/null
 
     # Install pipx and python3-venv
-    apt-get install -y bash git gpg-agent \
+    apt install -y bash git gpg-agent \
         python3-full \
-        ansible  2> /dev/null | grep packages | cut -d '.' -f 1
+        ansible  2> /dev/null
 }
 
 # Provision logic run by packer

--- a/blueprints/runzero-explorer/scripts/provision.sh
+++ b/blueprints/runzero-explorer/scripts/provision.sh
@@ -6,13 +6,17 @@ set -ex
 export PKR_BUILD_DIR="${1:-/ansible-collection-workstation}"
 export CLEANUP="${2:-true}"
 
+# Necessary for ansible to work properly
+export TERM=xterm-256color
+
 install_dependencies() {
     # Get latest packages and install aptitude
     apt-get update -y 2> /dev/null | grep packages | cut -d '.' -f 1
 
-    # Install ansible and associated pre-requisites
-    apt-get install -y bash git gpg-agent python3 python3-pip
-    python3 -m pip install --upgrade pip wheel setuptools ansible
+    # Install pipx and python3-venv
+    apt-get install -y bash git gpg-agent \
+        python3-full \
+        ansible  2> /dev/null | grep packages | cut -d '.' -f 1
 }
 
 # Provision logic run by packer

--- a/blueprints/runzero-explorer/scripts/provision.sh
+++ b/blueprints/runzero-explorer/scripts/provision.sh
@@ -6,22 +6,13 @@ set -ex
 export PKR_BUILD_DIR="${1:-/ansible-collection-workstation}"
 export CLEANUP="${2:-true}"
 
-# Necessary for ansible to work properly
-export TERM=xterm-256color
-
-# Set this only if on a debian-based system
-if [[ -f /etc/debian_version ]]; then
-    export DEBIAN_FRONTEND=noninteractive
-fi
-
 install_dependencies() {
-    # Get latest packages
-    apt update -y 2> /dev/null
+    # Get latest packages and install aptitude
+    apt-get update -y 2> /dev/null | grep packages | cut -d '.' -f 1
 
-    # Install pipx and python3-venv
-    apt install -y bash git gpg-agent \
-        python3-full \
-        ansible  2> /dev/null
+    # Install ansible and associated pre-requisites
+    apt-get install -y bash git gpg-agent python3 python3-pip
+    python3 -m pip install --upgrade pip wheel setuptools ansible
 }
 
 # Provision logic run by packer

--- a/cmd/imagebuilder.go
+++ b/cmd/imagebuilder.go
@@ -313,117 +313,6 @@ func initializeBlueprint(blueprintDir string) error {
 	return nil
 }
 
-func buildPackerImage(pTmpl *packer.BlueprintPacker, blueprint bp.Blueprint) error {
-	const maxRetries = 3
-	var lastError error
-	var buildDir string
-	var err error
-
-	for attempt := 1; attempt <= maxRetries; attempt++ {
-		buildDir, err = createBuildDir(blueprint)
-		if err != nil {
-			log.L().Errorf(
-				"Failed to create build directory: %v", err)
-			return err
-		}
-
-		if err := initializeBlueprint(buildDir); err != nil {
-			log.L().Errorf(
-				"Failed to initialize blueprint: %v", err)
-			return err
-		}
-
-		if err := viper.UnmarshalKey(containerKey, &pTmpl.Container); err != nil {
-			log.L().Errorf("Failed to unmarshal container parameters "+
-				"from %s config file: %v", blueprint.Name, err)
-			return err
-		}
-
-		templateDir := filepath.Join(buildDir, "packer_templates")
-		log.L().Printf("Packer template path: %s\n", templateDir)
-
-		args := []string{
-			"build",
-			"-var", fmt.Sprintf("base_image=%s", pTmpl.Base.Name),
-			"-var", fmt.Sprintf("base_image_version=%s", pTmpl.Base.Version),
-			"-var", fmt.Sprintf("blueprint_name=%s", pTmpl.Name),
-			"-var", fmt.Sprintf("container_user=%s", pTmpl.Container.User),
-			"-var", fmt.Sprintf("new_image_tag=%s", pTmpl.Tag.Name),
-			"-var", fmt.Sprintf("new_image_version=%s", pTmpl.Tag.Version),
-			"-var", fmt.Sprintf("provision_repo_path=%s", blueprint.ProvisioningRepo),
-			"-var", fmt.Sprintf("registry_server=%s", pTmpl.Container.Registry.Server),
-			"-var", fmt.Sprintf("registry_username=%s", pTmpl.Container.Registry.Username),
-			"-var", fmt.Sprintf("registry_cred=%s", githubToken),
-			"-var", fmt.Sprintf("workdir=%s", pTmpl.Container.Workdir),
-			templateDir,
-		}
-
-		if pTmpl.Container.Entrypoint != "" {
-			args = append(args, "-var", fmt.Sprintf("entrypoint=%s", pTmpl.Container.Entrypoint))
-		}
-
-		// Log the arguments with the token hidden
-		logArgs := make([]string, len(args))
-		copy(logArgs, args)
-		for i, arg := range logArgs {
-			if strings.Contains(arg, "registry_cred=") {
-				logArgs[i] = "-var registry_cred=<HIDDEN>"
-			}
-		}
-		log.L().Printf("Attempt %d - Packer Parameters: %s", attempt, logArgs)
-
-		if err := os.Chdir(buildDir); err != nil {
-			log.L().Errorf(
-				"Failed to change into the %s directory: %v", buildDir, err)
-			return err
-		}
-
-		cmd := sys.Cmd{
-			CmdString: "packer",
-			Args:      args,
-			OutputHandler: func(s string) {
-				log.L().Println(s)
-				// Parse image hashes from the output
-				if strings.Contains(s, "Imported Docker image: sha256:") {
-					parts := strings.Split(s, " ")
-					if len(parts) > 4 {
-						archParts := strings.Split(parts[1], ".")
-						if len(archParts) > 1 {
-							arch := strings.TrimSuffix(archParts[1], ":")
-							for _, part := range parts {
-								if strings.HasPrefix(part, "sha256:") {
-									hash := strings.TrimPrefix(part, "sha256:")
-									if pTmpl.ImageHashes == nil {
-										pTmpl.ImageHashes = make(map[string]string)
-									}
-									pTmpl.ImageHashes[arch] = hash
-									fmt.Printf("DEBUG: Updated ImageHashes: %v\n", pTmpl.ImageHashes) // Debug output
-									break
-								}
-							}
-						}
-					}
-				}
-			},
-		}
-
-		if _, err := cmd.RunCmd(); err != nil {
-			log.L().Errorf(
-				"Attempt %d: Failed to build container image from %s packer template: %s/%v", attempt, buildDir, pTmpl.Name, err)
-			lastError = err
-			continue // retry
-		}
-
-		log.L().Printf("Successfully built container image from the %s packer template as part of the %s blueprint",
-			pTmpl.Name, blueprint.Name)
-
-		return nil // success
-	}
-
-	// If the loop completes, it means all attempts failed
-	return fmt.Errorf("all attempts failed to build container image from %s packer template: %v", pTmpl.Name, lastError)
-}
-
 func validateToken(token string) error {
 	// Define the GitHub API URL for user authentication
 	url := "https://api.github.com/user"
@@ -457,4 +346,126 @@ func validateToken(token string) error {
 	}
 
 	return nil
+}
+
+func buildPackerImage(pTmpl *packer.BlueprintPacker, blueprint bp.Blueprint) error {
+	const maxRetries = 3
+	var lastError error
+
+	for attempt := 1; attempt <= maxRetries; attempt++ {
+		if err := buildImageAttempt(pTmpl, blueprint, attempt); err != nil {
+			lastError = err
+			continue // retry
+		}
+
+		log.L().Printf("Successfully built container image from the %s packer template as part of the %s blueprint",
+			pTmpl.Name, blueprint.Name)
+
+		return nil // success
+	}
+
+	// If the loop completes, it means all attempts failed
+	return fmt.Errorf("all attempts failed to build container image from %s packer template: %v", pTmpl.Name, lastError)
+}
+
+func buildImageAttempt(pTmpl *packer.BlueprintPacker, blueprint bp.Blueprint, attempt int) error {
+	buildDir, err := createBuildDir(blueprint)
+	if err != nil {
+		log.L().Errorf("Failed to create build directory: %v", err)
+		return err
+	}
+
+	if err := initializeBlueprint(buildDir); err != nil {
+		log.L().Errorf("Failed to initialize blueprint: %v", err)
+		return err
+	}
+
+	if err := viper.UnmarshalKey(containerKey, &pTmpl.Container); err != nil {
+		log.L().Errorf("Failed to unmarshal container parameters from %s config file: %v", blueprint.Name, err)
+		return err
+	}
+
+	templateDir := filepath.Join(buildDir, "packer_templates")
+	args := preparePackerArgs(pTmpl, blueprint, templateDir)
+
+	log.L().Printf("Attempt %d - Packer Parameters: %s", attempt, hideSensitiveArgs(args))
+
+	if err := os.Chdir(buildDir); err != nil {
+		log.L().Errorf("Failed to change into the %s directory: %v", buildDir, err)
+		return err
+	}
+
+	return runPackerBuild(args, pTmpl)
+}
+
+func preparePackerArgs(pTmpl *packer.BlueprintPacker, blueprint bp.Blueprint, templateDir string) []string {
+	args := []string{
+		"build",
+		"-var", fmt.Sprintf("base_image=%s", pTmpl.Base.Name),
+		"-var", fmt.Sprintf("base_image_version=%s", pTmpl.Base.Version),
+		"-var", fmt.Sprintf("blueprint_name=%s", pTmpl.Name),
+		"-var", fmt.Sprintf("container_user=%s", pTmpl.Container.User),
+		"-var", fmt.Sprintf("new_image_tag=%s", pTmpl.Tag.Name),
+		"-var", fmt.Sprintf("new_image_version=%s", pTmpl.Tag.Version),
+		"-var", fmt.Sprintf("provision_repo_path=%s", blueprint.ProvisioningRepo),
+		"-var", fmt.Sprintf("registry_server=%s", pTmpl.Container.Registry.Server),
+		"-var", fmt.Sprintf("registry_username=%s", pTmpl.Container.Registry.Username),
+		"-var", fmt.Sprintf("registry_cred=%s", githubToken),
+		"-var", fmt.Sprintf("workdir=%s", pTmpl.Container.Workdir),
+		templateDir,
+	}
+
+	if pTmpl.Container.Entrypoint != "" {
+		args = append(args, "-var", fmt.Sprintf("entrypoint=%s", pTmpl.Container.Entrypoint))
+	}
+
+	return args
+}
+
+func hideSensitiveArgs(args []string) []string {
+	logArgs := make([]string, len(args))
+	copy(logArgs, args)
+	for i, arg := range logArgs {
+		if strings.Contains(arg, "registry_cred=") {
+			logArgs[i] = "-var registry_cred=<HIDDEN>"
+		}
+	}
+	return logArgs
+}
+
+func runPackerBuild(args []string, pTmpl *packer.BlueprintPacker) error {
+	cmd := sys.Cmd{
+		CmdString: "packer",
+		Args:      args,
+		OutputHandler: func(s string) {
+			log.L().Println(s)
+			parseImageHashes(s, pTmpl)
+		},
+	}
+
+	_, err := cmd.RunCmd()
+	return err
+}
+
+func parseImageHashes(output string, pTmpl *packer.BlueprintPacker) {
+	if strings.Contains(output, "Imported Docker image: sha256:") {
+		parts := strings.Split(output, " ")
+		if len(parts) > 4 {
+			archParts := strings.Split(parts[1], ".")
+			if len(archParts) > 1 {
+				arch := strings.TrimSuffix(archParts[1], ":")
+				for _, part := range parts {
+					if strings.HasPrefix(part, "sha256:") {
+						hash := strings.TrimPrefix(part, "sha256:")
+						if pTmpl.ImageHashes == nil {
+							pTmpl.ImageHashes = make(map[string]string)
+						}
+						pTmpl.ImageHashes[arch] = hash
+						fmt.Printf("DEBUG: Updated ImageHashes: %v\n", pTmpl.ImageHashes) // Debug output
+						break
+					}
+				}
+			}
+		}
+	}
 }

--- a/cmd/imagebuilder.go
+++ b/cmd/imagebuilder.go
@@ -2,8 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"io"
-	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
@@ -115,7 +113,7 @@ func validateGitHubToken() error {
 		}
 	}
 
-	if err := validateToken(githubToken); err != nil {
+	if err := registry.ValidateToken(githubToken); err != nil {
 		return fmt.Errorf("GitHub token validation failed: %v", err)
 	}
 
@@ -305,41 +303,6 @@ func initializeBlueprint(blueprintDir string) error {
 		log.L().Errorf(
 			"Failed to initialize blueprint with packer init: %v", err)
 		return err
-	}
-
-	return nil
-}
-
-func validateToken(token string) error {
-	// Define the GitHub API URL for user authentication
-	url := "https://api.github.com/user"
-
-	// Create a new request
-	req, err := http.NewRequest("GET", url, nil)
-	if err != nil {
-		return fmt.Errorf("error creating request: %v", err)
-	}
-
-	// Set the Authorization header with the token
-	req.Header.Set("Authorization", "token "+token)
-
-	// Make the request
-	client := &http.Client{}
-	resp, err := client.Do(req)
-	if err != nil {
-		return fmt.Errorf("error making request: %v", err)
-	}
-	defer resp.Body.Close()
-
-	// Read the response body
-	_, err = io.ReadAll(resp.Body)
-	if err != nil {
-		return fmt.Errorf("error reading response: %v", err)
-	}
-
-	// Check if the status code is not 200
-	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("token validation failed with status code: %d", resp.StatusCode)
 	}
 
 	return nil

--- a/cmd/imagebuilder.go
+++ b/cmd/imagebuilder.go
@@ -152,8 +152,8 @@ func buildPackerImages() error {
 	}
 
 	wg.Wait() // Wait for all goroutines to finish
-
 	close(errChan)
+
 	var errOccurred bool
 	for err := range errChan {
 		if err != nil {

--- a/cmd/imagebuilder.go
+++ b/cmd/imagebuilder.go
@@ -365,12 +365,7 @@ func preparePackerArgs(pTmpl *packer.BlueprintPacker, blueprint bp.Blueprint, te
 		"-var", fmt.Sprintf("base_image_version=%s", pTmpl.Base.Version),
 		"-var", fmt.Sprintf("blueprint_name=%s", pTmpl.Name),
 		"-var", fmt.Sprintf("container_user=%s", pTmpl.Container.User),
-		"-var", fmt.Sprintf("new_image_tag=%s", pTmpl.Tag.Name),
-		"-var", fmt.Sprintf("new_image_version=%s", pTmpl.Tag.Version),
 		"-var", fmt.Sprintf("provision_repo_path=%s", blueprint.ProvisioningRepo),
-		"-var", fmt.Sprintf("registry_server=%s", pTmpl.Container.Registry.Server),
-		"-var", fmt.Sprintf("registry_username=%s", pTmpl.Container.Registry.Username),
-		"-var", fmt.Sprintf("registry_cred=%s", githubToken),
 		"-var", fmt.Sprintf("workdir=%s", pTmpl.Container.Workdir),
 		templateDir,
 	}

--- a/cmd/imagebuilder.go
+++ b/cmd/imagebuilder.go
@@ -165,7 +165,7 @@ func buildPackerImages() error {
 		return fmt.Errorf("errors occurred while building packer images")
 	}
 
-	fmt.Print(color.GreenString("All packer templates in %s blueprint built successfully!\n", blueprint.Name))
+	log.L().Printf(color.GreenString("All packer templates in %s blueprint built successfully!\n", blueprint.Name))
 	return nil
 }
 
@@ -347,7 +347,7 @@ func buildImageAttempt(pTmpl *packer.BlueprintPacker, blueprint bp.Blueprint, at
 	templateDir := filepath.Join(buildDir, "packer_templates")
 	args := preparePackerArgs(pTmpl, blueprint, templateDir)
 
-	log.L().Printf("Attempt %d - Packer Parameters: %s", attempt, hideSensitiveArgs(args))
+	log.L().Debugf("Attempt %d - Packer Parameters: %s", attempt, hideSensitiveArgs(args))
 
 	if err := os.Chdir(buildDir); err != nil {
 		log.L().Errorf("Failed to change into the %s directory: %v", buildDir, err)
@@ -415,7 +415,7 @@ func parseImageHashes(output string, pTmpl *packer.BlueprintPacker) {
 							pTmpl.ImageHashes = make(map[string]string)
 						}
 						pTmpl.ImageHashes[arch] = hash
-						fmt.Printf("DEBUG: Updated ImageHashes: %v\n", pTmpl.ImageHashes) // Debug output
+						log.L().Debug("Updated ImageHashes: %v\n", pTmpl.ImageHashes)
 						break
 					}
 				}

--- a/cmd/imagebuilder.go
+++ b/cmd/imagebuilder.go
@@ -135,7 +135,6 @@ func loadPackerTemplates() error {
 func buildPackerImages() error {
 	errChan := make(chan error, len(packerTemplates))
 	var wg sync.WaitGroup
-
 	for i, pTmpl := range packerTemplates {
 		wg.Add(1)
 		go func(i int, pTmpl *packer.BlueprintPacker) {

--- a/cmd/imagebuilder.go
+++ b/cmd/imagebuilder.go
@@ -77,9 +77,9 @@ func RunImageBuilder(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	if err := pushDockerImages(); err != nil {
-		return err
-	}
+	// if err := pushDockerImages(); err != nil {
+	// 	return err
+	// }
 
 	return nil
 }
@@ -341,7 +341,6 @@ func buildPackerImage(pTmpl packer.BlueprintPacker, blueprint bp.Blueprint) erro
 			"-var", fmt.Sprintf("base_image_version=%s", pTmpl.Base.Version),
 			"-var", fmt.Sprintf("blueprint_name=%s", pTmpl.Name),
 			"-var", fmt.Sprintf("container_user=%s", pTmpl.Container.User),
-			"-var", fmt.Sprintf("entrypoint=%s", pTmpl.Container.Entrypoint),
 			"-var", fmt.Sprintf("new_image_tag=%s", pTmpl.Tag.Name),
 			"-var", fmt.Sprintf("new_image_version=%s", pTmpl.Tag.Version),
 			"-var", fmt.Sprintf("provision_repo_path=%s", blueprint.ProvisioningRepo),
@@ -352,6 +351,10 @@ func buildPackerImage(pTmpl packer.BlueprintPacker, blueprint bp.Blueprint) erro
 			templateDir,
 		}
 
+		if pTmpl.Container.Entrypoint != "" {
+			args = append(args, "-var", fmt.Sprintf("entrypoint=%s", pTmpl.Container.Entrypoint))
+		}
+
 		// Log the arguments with the token hidden
 		logArgs := make([]string, len(args))
 		copy(logArgs, args)
@@ -360,7 +363,8 @@ func buildPackerImage(pTmpl packer.BlueprintPacker, blueprint bp.Blueprint) erro
 				logArgs[i] = "-var registry_cred=<HIDDEN>"
 			}
 		}
-		log.L().Debugf("Attempt %d - Packer Parameters: %s", attempt, logArgs)
+
+		log.L().Printf("Attempt %d - Packer Parameters: %s", attempt, logArgs)
 
 		if err := os.Chdir(buildDir); err != nil {
 			log.L().Errorf(

--- a/cmd/imagebuilder_test.go
+++ b/cmd/imagebuilder_test.go
@@ -91,7 +91,6 @@ container:
 				t.Fatalf("failed to get absolute path for blueprint dir: %v", err)
 			}
 
-			// Debug: Log the absolute path being used
 			t.Logf("Using blueprint config path: %s", absBlueprintDir)
 
 			cmd := &cobra.Command{}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -144,7 +144,7 @@ func depCheck() error {
 		return errors.New(errMsg)
 	}
 
-	log.L().Debug("All dependencies are satisfied.")
+	log.L().Println("All dependencies are satisfied.")
 
 	return nil
 }

--- a/config.yaml
+++ b/config.yaml
@@ -1,5 +1,5 @@
 ---
 log:
   format: text
-  level: debug
+  level: text
   path: /tmp/warpgate.log

--- a/pkg/registry/README.md
+++ b/pkg/registry/README.md
@@ -67,6 +67,16 @@ DockerTag tags a Docker image.
 
 ---
 
+### ValidateToken(string)
+
+```go
+ValidateToken(string) error
+```
+
+ValidateToken validates a GitHub token.
+
+---
+
 ## Installation
 
 To use the WarpGate/registry package, you first need to install it.

--- a/pkg/registry/github.go
+++ b/pkg/registry/github.go
@@ -1,0 +1,43 @@
+package registry
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+)
+
+// ValidateToken validates a GitHub token.
+func ValidateToken(token string) error {
+	// Define the GitHub API URL for user authentication
+	url := "https://api.github.com/user"
+
+	// Create a new request
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return fmt.Errorf("error creating request: %v", err)
+	}
+
+	// Set the Authorization header with the token
+	req.Header.Set("Authorization", "token "+token)
+
+	// Make the request
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("error making request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	// Read the response body
+	_, err = io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("error reading response: %v", err)
+	}
+
+	// Check if the status code is not 200
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("token validation failed with status code: %d", resp.StatusCode)
+	}
+
+	return nil
+}


### PR DESCRIPTION
**Added:**
- Added a map to store image hashes in BlueprintPacker struct for manifest creation.

**Changed:**
- Removed tmate session setup from GitHub Actions workflow for image builder.
- Updated versions of kubectl, helm, and packer in `.tool-versions`.
- Updated the required plugin version for docker in Packer templates.
- Simplified Packer templates by removing redundant labels and entrypoints.
- Refactored Packer template sources and build configuration for clarity.
- Updated variable definitions in Packer templates for consistency.
- Refactored image builder Go code to improve error handling and image tagging.
- Added image hash parsing in Go code to support manifest creation.
- Moved GitHub token validation to a separate file in the registry package.

