### PR TITLE
Switch to GitHub App Token for Authentication

### DIFF
--- a/.github/workflows/dockerfile-image-builder.yaml
+++ b/.github/workflows/dockerfile-image-builder.yaml
@@ -5,21 +5,25 @@ on:
   pull_request:
   push:
     branches: [main]
-
 concurrency:
   cancel-in-progress: true
   group: "${{ github.workflow }}"
-
 env:
   PRODUCT_VERSION: "latest"
   IMAGE_NAME: ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}
   # # Used for testing locally with act
   # IMAGE_NAME: ghcr.io/${{ secrets.GITHUB_REPOSITORY_OWNER }}/${{ secrets.GITHUB_REPOSITORY_NAME }}
-
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
     steps:
+      - name: Generate Token
+        uses: actions/create-github-app-token@c1a285145b9d317df6ced56c09f525b5c2b6f755 # v1.11.1
+        id: app-token
+        with:
+          app-id: "${{ secrets.BOT_APP_ID }}"
+          private-key: "${{ secrets.BOT_APP_PRIVATE_KEY }}"
+
       - name: Set up git repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
@@ -36,7 +40,7 @@ jobs:
           username: ${{ github.repository_owner }}
           # # Used for testing locally with act
           # username: ${{ secrets.GITHUB_REPOSITORY_OWNER }}
-          password: ${{ secrets.BOT_TOKEN }}
+          password: ${{ steps.app-token.outputs.token }}
 
       - name: Convert IMAGE_NAME to lowercase
         run: echo "IMAGE_NAME=$(echo ${{ env.IMAGE_NAME }} | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV

--- a/.github/workflows/dockerfile-image-builder.yaml
+++ b/.github/workflows/dockerfile-image-builder.yaml
@@ -24,13 +24,6 @@ jobs:
   build-and-push:
     runs-on: ubuntu-latest
     steps:
-      - name: Generate Token
-        uses: actions/create-github-app-token@c1a285145b9d317df6ced56c09f525b5c2b6f755 # v1.11.1
-        id: app-token
-        with:
-          app-id: "${{ secrets.BOT_APP_ID }}"
-          private-key: "${{ secrets.BOT_APP_PRIVATE_KEY }}"
-
       - name: Set up git repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
@@ -45,7 +38,6 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
-          # password: ${{ steps.app-token.outputs.token }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Convert IMAGE_NAME to lowercase

--- a/.github/workflows/dockerfile-image-builder.yaml
+++ b/.github/workflows/dockerfile-image-builder.yaml
@@ -5,9 +5,16 @@ on:
   pull_request:
   push:
     branches: [main]
+
 concurrency:
   cancel-in-progress: true
   group: "${{ github.workflow }}"
+
+permissions:
+  id-token: write
+  contents: read
+  packages: write
+
 env:
   PRODUCT_VERSION: "latest"
   IMAGE_NAME: ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}
@@ -38,9 +45,8 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
-          # # Used for testing locally with act
-          # username: ${{ secrets.GITHUB_REPOSITORY_OWNER }}
-          password: ${{ steps.app-token.outputs.token }}
+          # password: ${{ steps.app-token.outputs.token }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Convert IMAGE_NAME to lowercase
         run: echo "IMAGE_NAME=$(echo ${{ env.IMAGE_NAME }} | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV

--- a/.github/workflows/goreleaser.yaml
+++ b/.github/workflows/goreleaser.yaml
@@ -4,12 +4,18 @@ on:
   push:
     tags:
       - "*"
-
 jobs:
   goreleaser:
     name: Run go releaser
     runs-on: ubuntu-latest
     steps:
+      - name: Generate Token
+        uses: actions/create-github-app-token@c1a285145b9d317df6ced56c09f525b5c2b6f755 # v1.11.1
+        id: app-token
+        with:
+          app-id: "${{ secrets.BOT_APP_ID }}"
+          private-key: "${{ secrets.BOT_APP_PRIVATE_KEY }}"
+
       - name: Set up git repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
@@ -37,7 +43,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5
         with:
-          go-version: "1.22"
+          go-version: "1.23.6"
           cache-dependency-path: "**/*.sum"
 
       - name: Fix GOPATH
@@ -50,4 +56,4 @@ jobs:
           version: latest
           args: release --clean
         env:
-          GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/meta-labeler.yaml
+++ b/.github/workflows/meta-labeler.yaml
@@ -1,17 +1,28 @@
 ---
-name: "Meta Labeler"
+name: "Labeler"
 on:
-  workflow_dispatch:
-  pull_request:
+  pull_request_target:
     branches: ["main"]
+    types: ["opened", "synchronize"]
+
+permissions:
+  contents: read
+  pull-requests: write
 
 jobs:
   labeler:
     name: Labeler
     runs-on: ubuntu-latest
     steps:
+      - name: Generate Token
+        uses: actions/create-github-app-token@c1a285145b9d317df6ced56c09f525b5c2b6f755 # v1.11.1
+        id: app-token
+        with:
+          app-id: "${{ secrets.BOT_APP_ID }}"
+          private-key: "${{ secrets.BOT_APP_PRIVATE_KEY }}"
+
       - name: Labeler
         uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5.0.0
         with:
           configuration-path: .github/labeler.yaml
-          repo-token: "${{ secrets.BOT_TOKEN }}"
+          repo-token: "${{ steps.app-token.outputs.token }}"

--- a/.github/workflows/meta-sync-labels.yaml
+++ b/.github/workflows/meta-sync-labels.yaml
@@ -6,19 +6,31 @@ on:
     branches: ["main"]
     paths: [".github/labels.yaml"]
 
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
 jobs:
   labels:
     name: Sync Labels
     runs-on: ubuntu-latest
     steps:
+      - name: Generate Token
+        uses: actions/create-github-app-token@c1a285145b9d317df6ced56c09f525b5c2b6f755 # v1.11.1
+        id: app-token
+        with:
+          app-id: "${{ secrets.BOT_APP_ID }}"
+          private-key: "${{ secrets.BOT_APP_PRIVATE_KEY }}"
+
       - name: Set up git repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          token: "${{ secrets.BOT_TOKEN }}"
+          token: "${{ steps.app-token.outputs.token }}"
 
       - name: Sync Labels
         uses: EndBug/label-sync@52074158190acb45f3077f9099fea818aa43f97a # v2.3.3
         with:
           config-file: .github/labels.yaml
-          token: "${{ secrets.BOT_TOKEN }}"
+          token: "${{ steps.app-token.outputs.token }}"
           delete-other-labels: true

--- a/docs/act.md
+++ b/docs/act.md
@@ -2,7 +2,7 @@
 
 1. Install [Act](https://github.com/nektos/act)
 
-2. Create a `.secrets` file with the following content:
+1. Create a `.secrets` file with the following content:
 
    ```bash
     BOT_TOKEN=your_github_token
@@ -10,7 +10,7 @@
     GITHUB_REPOSITORY_OWNER=cowdogmoo
    ```
 
-3. Uncomment relevant sections in
+1. Uncomment relevant sections in
    `.github/workflows/dockerfile-image-builder.yaml` and run the following command:
 
    ```bash


### PR DESCRIPTION
**Key Changes:**

- **Replaced `BOT_TOKEN`** with `GITHUB_TOKEN` for authentication.
- **Fixed GHCR authentication** by ensuring correct repository linking.
- **Resolved `InvalidDefaultArgInFrom`** issue in `Dockerfile`.
- **Updated GoReleaser authentication** for publishing releases.
- **Adjusted permissions for package access** to allow successful `docker push`.
- **Refactored label workflows** to use app-generated tokens.
- **Upgraded Go version** in `goreleaser.yaml` from `1.22` to `1.23.6`.

**Added:**
- `permissions` settings ensuring GHCR access.
- Support for `GITHUB_TOKEN` in authentication steps.
- Default `BASE_IMAGE_ARCH` value to fix `docker-bake.hcl` issues.

**Changed:**
- `dockerfile-image-builder.yaml` now uses `GITHUB_TOKEN` for GHCR login.
- `goreleaser.yaml` authentication adjusted to align with updated tokens.
- `meta-labeler.yaml` and `meta-sync-labels.yaml` now use app-generated tokens.
- **Workflow now ensures lowercase IMAGE_NAME** for consistent tagging.

**Removed:**
- Direct use of `BOT_TOKEN` in GitHub Actions.
- Redundant manual repository token assignments.
- Previously failing `app-token` authentication mechanism.