### PR TITLE
feat: add dynamic AMI resolution via EC2 filters and validation support

### DIFF
--- a/builder/ami/imagebuilder.go
+++ b/builder/ami/imagebuilder.go
@@ -27,10 +27,13 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/aws/aws-sdk-go-v2/service/imagebuilder"
 	"github.com/aws/aws-sdk-go-v2/service/imagebuilder/types"
 	"github.com/aws/aws-sdk-go-v2/service/ssm"
@@ -572,22 +575,93 @@ func (b *ImageBuilder) resolveSSMParameterARN(ctx context.Context, parentImage s
 	return parentImage, nil
 }
 
-func (b *ImageBuilder) createImageRecipe(ctx context.Context, config builder.Config, componentARNs []string, target *builder.Target) (string, error) {
-	logging.InfoContext(ctx, "Creating image recipe")
+// resolveAMIFilters resolves AMI filters to the latest matching AMI ID using EC2 DescribeImages.
+func (b *ImageBuilder) resolveAMIFilters(ctx context.Context, filters *builder.AMIFilterConfig) (string, error) {
+	if len(filters.Owners) == 0 {
+		return "", fmt.Errorf("ami_filters.owners must specify at least one owner")
+	}
+	if len(filters.Filters) == 0 {
+		return "", fmt.Errorf("ami_filters.filters must specify at least one filter")
+	}
+
+	ec2Filters := make([]ec2types.Filter, 0, len(filters.Filters))
+	for name, value := range filters.Filters {
+		ec2Filters = append(ec2Filters, ec2types.Filter{
+			Name:   aws.String(name),
+			Values: []string{value},
+		})
+	}
+
+	// Always filter for available images unless the user explicitly set "state"
+	if _, hasState := filters.Filters["state"]; !hasState {
+		ec2Filters = append(ec2Filters, ec2types.Filter{
+			Name:   aws.String("state"),
+			Values: []string{"available"},
+		})
+	}
+
+	input := &ec2.DescribeImagesInput{
+		Owners:  filters.Owners,
+		Filters: ec2Filters,
+	}
+
+	logging.InfoContext(ctx, "Resolving AMI from filters (owners: %v, filters: %d)", filters.Owners, len(filters.Filters))
+
+	output, err := b.clients.EC2.DescribeImages(ctx, input)
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve AMI from filters: %w", err)
+	}
+
+	if len(output.Images) == 0 {
+		filterDesc := make([]string, 0, len(filters.Filters))
+		for k, v := range filters.Filters {
+			filterDesc = append(filterDesc, fmt.Sprintf("%s=%s", k, v))
+		}
+		return "", fmt.Errorf("no AMIs found matching filters (owners: %v, filters: [%s])",
+			filters.Owners, strings.Join(filterDesc, ", "))
+	}
+
+	// Sort by CreationDate descending (RFC 3339 strings sort lexicographically)
+	sort.Slice(output.Images, func(i, j int) bool {
+		return aws.ToString(output.Images[i].CreationDate) > aws.ToString(output.Images[j].CreationDate)
+	})
+
+	selected := output.Images[0]
+	amiID := aws.ToString(selected.ImageId)
+	amiName := aws.ToString(selected.Name)
+	logging.InfoContext(ctx, "Resolved AMI from filters: %s (%s, created: %s)",
+		amiID, amiName, aws.ToString(selected.CreationDate))
+
+	return amiID, nil
+}
+
+// resolveParentImage resolves the parent image from config, handling:
+//   - AMI Filters (resolved via EC2 DescribeImages)
+//   - Direct AMI IDs (passthrough)
+//   - SSM Parameter ARNs (resolved via SSM GetParameter)
+func (b *ImageBuilder) resolveParentImage(ctx context.Context, config builder.Config) (string, error) {
+	if config.Base.AMIFilters != nil {
+		return b.resolveAMIFilters(ctx, config.Base.AMIFilters)
+	}
 
 	parentImage := config.Base.Image
 	if parentImage == "" {
 		parentImage = b.globalConfig.AWS.AMI.DefaultParentImage
 		if parentImage == "" {
-			return "", fmt.Errorf("parent image (base AMI) must be specified in template config or global config (aws.ami.default_parent_image)")
+			return "", fmt.Errorf("parent image must be specified via base.image, base.ami_filters, or global config (aws.ami.default_parent_image)")
 		}
 	}
 
-	resolved, err := b.resolveSSMParameterARN(ctx, parentImage)
+	return b.resolveSSMParameterARN(ctx, parentImage)
+}
+
+func (b *ImageBuilder) createImageRecipe(ctx context.Context, config builder.Config, componentARNs []string, target *builder.Target) (string, error) {
+	logging.InfoContext(ctx, "Creating image recipe")
+
+	parentImage, err := b.resolveParentImage(ctx, config)
 	if err != nil {
 		return "", err
 	}
-	parentImage = resolved
 
 	components := make([]types.ComponentConfiguration, 0, len(componentARNs))
 	for _, arn := range componentARNs {

--- a/builder/ami/imagebuilder_test.go
+++ b/builder/ami/imagebuilder_test.go
@@ -2607,6 +2607,299 @@ func TestResolveSSMParameterARN(t *testing.T) {
 	}
 }
 
+func TestResolveAMIFilters(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name             string
+		filters          *builder.AMIFilterConfig
+		describeFunc     func(ctx context.Context, params *ec2.DescribeImagesInput, optFns ...func(*ec2.Options)) (*ec2.DescribeImagesOutput, error)
+		expectedResult   string
+		expectError      bool
+		expectedErrorMsg string
+	}{
+		{
+			name: "single match returns AMI ID",
+			filters: &builder.AMIFilterConfig{
+				Owners:  []string{"679593333241"},
+				Filters: map[string]string{"name": "kali-linux-2024.*"},
+			},
+			describeFunc: func(ctx context.Context, params *ec2.DescribeImagesInput, optFns ...func(*ec2.Options)) (*ec2.DescribeImagesOutput, error) {
+				assert.Equal(t, []string{"679593333241"}, params.Owners)
+				return &ec2.DescribeImagesOutput{
+					Images: []ec2types.Image{
+						{
+							ImageId:      aws.String("ami-kali123"),
+							Name:         aws.String("kali-linux-2024.1"),
+							CreationDate: aws.String("2024-03-15T00:00:00.000Z"),
+						},
+					},
+				}, nil
+			},
+			expectedResult: "ami-kali123",
+		},
+		{
+			name: "multiple matches returns most recent",
+			filters: &builder.AMIFilterConfig{
+				Owners:  []string{"679593333241"},
+				Filters: map[string]string{"name": "kali-linux-*"},
+			},
+			describeFunc: func(ctx context.Context, params *ec2.DescribeImagesInput, optFns ...func(*ec2.Options)) (*ec2.DescribeImagesOutput, error) {
+				return &ec2.DescribeImagesOutput{
+					Images: []ec2types.Image{
+						{
+							ImageId:      aws.String("ami-older"),
+							Name:         aws.String("kali-linux-2023.4"),
+							CreationDate: aws.String("2023-12-01T00:00:00.000Z"),
+						},
+						{
+							ImageId:      aws.String("ami-newest"),
+							Name:         aws.String("kali-linux-2024.2"),
+							CreationDate: aws.String("2024-06-15T00:00:00.000Z"),
+						},
+						{
+							ImageId:      aws.String("ami-middle"),
+							Name:         aws.String("kali-linux-2024.1"),
+							CreationDate: aws.String("2024-03-15T00:00:00.000Z"),
+						},
+					},
+				}, nil
+			},
+			expectedResult: "ami-newest",
+		},
+		{
+			name: "no matches returns error",
+			filters: &builder.AMIFilterConfig{
+				Owners:  []string{"679593333241"},
+				Filters: map[string]string{"name": "nonexistent-*"},
+			},
+			describeFunc: func(ctx context.Context, params *ec2.DescribeImagesInput, optFns ...func(*ec2.Options)) (*ec2.DescribeImagesOutput, error) {
+				return &ec2.DescribeImagesOutput{Images: []ec2types.Image{}}, nil
+			},
+			expectError:      true,
+			expectedErrorMsg: "no AMIs found matching filters",
+		},
+		{
+			name: "empty owners returns error",
+			filters: &builder.AMIFilterConfig{
+				Owners:  []string{},
+				Filters: map[string]string{"name": "kali-*"},
+			},
+			expectError:      true,
+			expectedErrorMsg: "ami_filters.owners must specify at least one owner",
+		},
+		{
+			name: "empty filters returns error",
+			filters: &builder.AMIFilterConfig{
+				Owners:  []string{"679593333241"},
+				Filters: map[string]string{},
+			},
+			expectError:      true,
+			expectedErrorMsg: "ami_filters.filters must specify at least one filter",
+		},
+		{
+			name: "API error returns wrapped error",
+			filters: &builder.AMIFilterConfig{
+				Owners:  []string{"679593333241"},
+				Filters: map[string]string{"name": "kali-*"},
+			},
+			describeFunc: func(ctx context.Context, params *ec2.DescribeImagesInput, optFns ...func(*ec2.Options)) (*ec2.DescribeImagesOutput, error) {
+				return nil, fmt.Errorf("access denied")
+			},
+			expectError:      true,
+			expectedErrorMsg: "failed to resolve AMI from filters",
+		},
+		{
+			name: "adds state=available filter by default",
+			filters: &builder.AMIFilterConfig{
+				Owners:  []string{"123456789012"},
+				Filters: map[string]string{"name": "my-ami-*"},
+			},
+			describeFunc: func(ctx context.Context, params *ec2.DescribeImagesInput, optFns ...func(*ec2.Options)) (*ec2.DescribeImagesOutput, error) {
+				// Verify state=available filter was added
+				hasStateFilter := false
+				for _, f := range params.Filters {
+					if aws.ToString(f.Name) == "state" {
+						hasStateFilter = true
+						assert.Equal(t, []string{"available"}, f.Values)
+					}
+				}
+				assert.True(t, hasStateFilter, "expected state=available filter")
+				return &ec2.DescribeImagesOutput{
+					Images: []ec2types.Image{
+						{
+							ImageId:      aws.String("ami-test123"),
+							Name:         aws.String("my-ami-v1"),
+							CreationDate: aws.String("2024-01-01T00:00:00.000Z"),
+						},
+					},
+				}, nil
+			},
+			expectedResult: "ami-test123",
+		},
+		{
+			name: "explicit state filter overrides default",
+			filters: &builder.AMIFilterConfig{
+				Owners:  []string{"123456789012"},
+				Filters: map[string]string{"name": "my-ami-*", "state": "pending"},
+			},
+			describeFunc: func(ctx context.Context, params *ec2.DescribeImagesInput, optFns ...func(*ec2.Options)) (*ec2.DescribeImagesOutput, error) {
+				stateCount := 0
+				for _, f := range params.Filters {
+					if aws.ToString(f.Name) == "state" {
+						stateCount++
+					}
+				}
+				assert.Equal(t, 1, stateCount, "should have exactly one state filter")
+				return &ec2.DescribeImagesOutput{
+					Images: []ec2types.Image{
+						{
+							ImageId:      aws.String("ami-pending1"),
+							Name:         aws.String("my-ami-pending"),
+							CreationDate: aws.String("2024-01-01T00:00:00.000Z"),
+						},
+					},
+				}, nil
+			},
+			expectedResult: "ami-pending1",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			clients, mocks := newMockAWSClients()
+			if tc.describeFunc != nil {
+				mocks.ec2.DescribeImagesFunc = tc.describeFunc
+			}
+
+			ib := &ImageBuilder{
+				clients: clients,
+			}
+
+			result, err := ib.resolveAMIFilters(context.Background(), tc.filters)
+			if tc.expectError {
+				require.Error(t, err)
+				if tc.expectedErrorMsg != "" {
+					assert.Contains(t, err.Error(), tc.expectedErrorMsg)
+				}
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.expectedResult, result)
+		})
+	}
+}
+
+func TestResolveParentImage(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		config         builder.Config
+		globalDefault  string
+		describeFunc   func(ctx context.Context, params *ec2.DescribeImagesInput, optFns ...func(*ec2.Options)) (*ec2.DescribeImagesOutput, error)
+		getParamFunc   func(ctx context.Context, params *ssm.GetParameterInput, optFns ...func(*ssm.Options)) (*ssm.GetParameterOutput, error)
+		expectedResult string
+		expectError    bool
+	}{
+		{
+			name: "ami_filters delegates to resolveAMIFilters",
+			config: builder.Config{
+				Base: builder.BaseImage{
+					AMIFilters: &builder.AMIFilterConfig{
+						Owners:  []string{"679593333241"},
+						Filters: map[string]string{"name": "kali-*"},
+					},
+				},
+			},
+			describeFunc: func(ctx context.Context, params *ec2.DescribeImagesInput, optFns ...func(*ec2.Options)) (*ec2.DescribeImagesOutput, error) {
+				return &ec2.DescribeImagesOutput{
+					Images: []ec2types.Image{
+						{
+							ImageId:      aws.String("ami-kali456"),
+							Name:         aws.String("kali-2024"),
+							CreationDate: aws.String("2024-06-01T00:00:00.000Z"),
+						},
+					},
+				}, nil
+			},
+			expectedResult: "ami-kali456",
+		},
+		{
+			name: "direct AMI ID passes through",
+			config: builder.Config{
+				Base: builder.BaseImage{
+					Image: "ami-direct123",
+				},
+			},
+			expectedResult: "ami-direct123",
+		},
+		{
+			name: "SSM ARN delegates to resolveSSMParameterARN",
+			config: builder.Config{
+				Base: builder.BaseImage{
+					Image: "arn:aws:ssm:us-east-1:123456789012:parameter/ami/ubuntu",
+				},
+			},
+			getParamFunc: func(ctx context.Context, params *ssm.GetParameterInput, optFns ...func(*ssm.Options)) (*ssm.GetParameterOutput, error) {
+				return &ssm.GetParameterOutput{
+					Parameter: &ssmtypes.Parameter{
+						Value: aws.String("ami-ssm789"),
+					},
+				}, nil
+			},
+			expectedResult: "ami-ssm789",
+		},
+		{
+			name: "falls back to global default",
+			config: builder.Config{
+				Base: builder.BaseImage{},
+			},
+			globalDefault:  "ami-global999",
+			expectedResult: "ami-global999",
+		},
+		{
+			name: "no image and no global default returns error",
+			config: builder.Config{
+				Base: builder.BaseImage{},
+			},
+			expectError: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			clients, mocks := newMockAWSClients()
+			if tc.describeFunc != nil {
+				mocks.ec2.DescribeImagesFunc = tc.describeFunc
+			}
+			if tc.getParamFunc != nil {
+				mocks.ssm.GetParameterFunc = tc.getParamFunc
+			}
+
+			globalCfg := &config.Config{}
+			globalCfg.AWS.AMI.DefaultParentImage = tc.globalDefault
+
+			ib := &ImageBuilder{
+				clients:      clients,
+				globalConfig: globalCfg,
+			}
+
+			result, err := ib.resolveParentImage(context.Background(), tc.config)
+			if tc.expectError {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.expectedResult, result)
+		})
+	}
+}
+
 func TestCopy(t *testing.T) {
 	t.Parallel()
 

--- a/builder/ami/validation.go
+++ b/builder/ami/validation.go
@@ -129,63 +129,68 @@ func (v *Validator) ValidateBuild(ctx context.Context, config builder.Config, ta
 
 // validateBasicConfig validates basic configuration fields
 func (v *Validator) validateBasicConfig(result *ValidationResult, config builder.Config, target *builder.Target) {
-	// Check template name
-	if config.Name == "" {
-		result.AddError("Template name is required")
-	}
-	if config.Name != "" {
-		result.AddInfo("Template name: %s", config.Name)
-	}
+	validateRequiredField(result, config.Name, "Template name")
+	validateRequiredField(result, config.Version, "Template version")
 
-	// Check version
-	if config.Version == "" {
-		result.AddError("Template version is required")
-	}
-	if config.Version != "" {
-		result.AddInfo("Template version: %s", config.Version)
-	}
+	v.validateRegion(result, target)
+	v.validateBaseImageConfig(result, config)
 
-	// Check region
+	validateOptionalField(result, target.InstanceType, "Instance type",
+		"Instance type not specified, will use default from global config")
+	validateOptionalField(result, target.InstanceProfileName, "Instance profile",
+		"Instance profile not specified in template, will use global config value")
+}
+
+// validateRequiredField checks a required string field and adds error/info to the result.
+func validateRequiredField(result *ValidationResult, value, label string) {
+	if value == "" {
+		result.AddError("%s is required", label)
+	} else {
+		result.AddInfo("%s: %s", label, value)
+	}
+}
+
+// validateOptionalField checks an optional string field and adds warning/info to the result.
+func validateOptionalField(result *ValidationResult, value, label, warningMsg string) {
+	if value == "" {
+		result.AddWarning("%s", warningMsg)
+	} else {
+		result.AddInfo("%s: %s", label, value)
+	}
+}
+
+// validateRegion validates the AWS region is configured.
+func (v *Validator) validateRegion(result *ValidationResult, target *builder.Target) {
 	region := target.Region
 	if region == "" && v.clients != nil {
 		region = v.clients.GetRegion()
 	}
 	if region == "" {
 		result.AddError("AWS region must be specified (--region flag, template config, or global config)")
-	}
-	if region != "" {
+	} else {
 		result.AddInfo("Target region: %s", region)
 	}
+}
 
-	// Check base image
-	if config.Base.Image == "" {
-		result.AddError("Base image (parent AMI) must be specified in template config (base.image)")
+// validateBaseImageConfig validates that a base image source is configured.
+func (v *Validator) validateBaseImageConfig(result *ValidationResult, config builder.Config) {
+	if config.Base.Image == "" && config.Base.AMIFilters == nil {
+		result.AddError("Base image (parent AMI) must be specified in template config (base.image or base.ami_filters)")
 	}
 	if config.Base.Image != "" {
 		result.AddInfo("Base image: %s", config.Base.Image)
 	}
-
-	// Check instance type
-	if target.InstanceType == "" {
-		result.AddWarning("Instance type not specified, will use default from global config")
-	}
-	if target.InstanceType != "" {
-		result.AddInfo("Instance type: %s", target.InstanceType)
-	}
-
-	// Check instance profile
-	if target.InstanceProfileName == "" {
-		result.AddWarning("Instance profile not specified in template, will use global config value")
-	}
-	if target.InstanceProfileName != "" {
-		result.AddInfo("Instance profile: %s", target.InstanceProfileName)
+	if config.Base.AMIFilters != nil {
+		result.AddInfo("Base image: using AMI filters (owners: %v)", config.Base.AMIFilters.Owners)
 	}
 }
 
 // validateAWSResources validates AWS resources exist and are accessible
 func (v *Validator) validateAWSResources(ctx context.Context, result *ValidationResult, config builder.Config, target *builder.Target) {
 	// Validate base AMI exists
-	if config.Base.Image != "" && strings.HasPrefix(config.Base.Image, "ami-") {
+	if config.Base.AMIFilters != nil {
+		v.validateAMIFilters(ctx, result, config.Base.AMIFilters)
+	} else if config.Base.Image != "" && strings.HasPrefix(config.Base.Image, "ami-") {
 		v.validateAMI(ctx, result, config.Base.Image)
 	}
 
@@ -248,6 +253,66 @@ func (v *Validator) validateAMI(ctx context.Context, result *ValidationResult, a
 		return
 	}
 	result.AddInfo("Base AMI platform: Linux")
+}
+
+// validateAMIFilters performs a dry-run validation of AMI filters by executing
+// the DescribeImages call and reporting how many AMIs match.
+func (v *Validator) validateAMIFilters(ctx context.Context, result *ValidationResult, filters *builder.AMIFilterConfig) {
+	if len(filters.Owners) == 0 {
+		result.AddError("ami_filters.owners must specify at least one owner")
+		return
+	}
+	if len(filters.Filters) == 0 {
+		result.AddError("ami_filters.filters must specify at least one filter")
+		return
+	}
+
+	ec2Filters := make([]ec2types.Filter, 0, len(filters.Filters))
+	for name, value := range filters.Filters {
+		ec2Filters = append(ec2Filters, ec2types.Filter{
+			Name:   aws.String(name),
+			Values: []string{value},
+		})
+	}
+	if _, hasState := filters.Filters["state"]; !hasState {
+		ec2Filters = append(ec2Filters, ec2types.Filter{
+			Name:   aws.String("state"),
+			Values: []string{"available"},
+		})
+	}
+
+	input := &ec2.DescribeImagesInput{
+		Owners:  filters.Owners,
+		Filters: ec2Filters,
+	}
+
+	output, err := v.clients.EC2.DescribeImages(ctx, input)
+	if err != nil {
+		result.AddError("Failed to validate AMI filters: %v", err)
+		return
+	}
+
+	if len(output.Images) == 0 {
+		result.AddError("No AMIs found matching filters (owners: %v)", filters.Owners)
+		return
+	}
+
+	result.AddInfo("AMI filters matched %d image(s)", len(output.Images))
+
+	// Report which AMI would be selected (most recent)
+	latest := output.Images[0]
+	for _, img := range output.Images[1:] {
+		if aws.ToString(img.CreationDate) > aws.ToString(latest.CreationDate) {
+			latest = img
+		}
+	}
+
+	name := "unnamed"
+	if latest.Name != nil {
+		name = *latest.Name
+	}
+	result.AddInfo("Latest matching AMI: %s (%s, created: %s)",
+		aws.ToString(latest.ImageId), name, aws.ToString(latest.CreationDate))
 }
 
 // validateInstanceType checks if an instance type is available in the current region

--- a/builder/ami/validation_test.go
+++ b/builder/ami/validation_test.go
@@ -1321,6 +1321,122 @@ func TestValidateBuild(t *testing.T) {
 	}
 }
 
+func TestValidateAMIFilters(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		filters      *builder.AMIFilterConfig
+		describeFunc func(ctx context.Context, params *ec2.DescribeImagesInput, optFns ...func(*ec2.Options)) (*ec2.DescribeImagesOutput, error)
+		wantErrors   int
+		wantInfo     int
+		errContains  string
+		infoContains string
+	}{
+		{
+			name: "valid filters with matches",
+			filters: &builder.AMIFilterConfig{
+				Owners:  []string{"679593333241"},
+				Filters: map[string]string{"name": "kali-linux-*"},
+			},
+			describeFunc: func(ctx context.Context, params *ec2.DescribeImagesInput, optFns ...func(*ec2.Options)) (*ec2.DescribeImagesOutput, error) {
+				return &ec2.DescribeImagesOutput{
+					Images: []ec2types.Image{
+						{
+							ImageId:      aws.String("ami-old"),
+							Name:         aws.String("kali-linux-2023"),
+							CreationDate: aws.String("2023-06-01T00:00:00.000Z"),
+						},
+						{
+							ImageId:      aws.String("ami-new"),
+							Name:         aws.String("kali-linux-2024"),
+							CreationDate: aws.String("2024-06-01T00:00:00.000Z"),
+						},
+					},
+				}, nil
+			},
+			wantErrors:   0,
+			wantInfo:     2,
+			infoContains: "ami-new",
+		},
+		{
+			name: "empty owners",
+			filters: &builder.AMIFilterConfig{
+				Owners:  []string{},
+				Filters: map[string]string{"name": "kali-*"},
+			},
+			wantErrors:  1,
+			errContains: "at least one owner",
+		},
+		{
+			name: "empty filters",
+			filters: &builder.AMIFilterConfig{
+				Owners:  []string{"679593333241"},
+				Filters: map[string]string{},
+			},
+			wantErrors:  1,
+			errContains: "at least one filter",
+		},
+		{
+			name: "no matches",
+			filters: &builder.AMIFilterConfig{
+				Owners:  []string{"679593333241"},
+				Filters: map[string]string{"name": "nonexistent-*"},
+			},
+			describeFunc: func(ctx context.Context, params *ec2.DescribeImagesInput, optFns ...func(*ec2.Options)) (*ec2.DescribeImagesOutput, error) {
+				return &ec2.DescribeImagesOutput{Images: []ec2types.Image{}}, nil
+			},
+			wantErrors:  1,
+			errContains: "No AMIs found",
+		},
+		{
+			name: "API error",
+			filters: &builder.AMIFilterConfig{
+				Owners:  []string{"679593333241"},
+				Filters: map[string]string{"name": "kali-*"},
+			},
+			describeFunc: func(ctx context.Context, params *ec2.DescribeImagesInput, optFns ...func(*ec2.Options)) (*ec2.DescribeImagesOutput, error) {
+				return nil, fmt.Errorf("access denied")
+			},
+			wantErrors:  1,
+			errContains: "Failed to validate AMI filters",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			clients, mocks := newMockAWSClients()
+			if tc.describeFunc != nil {
+				mocks.ec2.DescribeImagesFunc = tc.describeFunc
+			}
+
+			v := NewValidator(clients)
+			result := &ValidationResult{Valid: true}
+			v.validateAMIFilters(context.Background(), result, tc.filters)
+
+			assert.Len(t, result.Errors, tc.wantErrors)
+			if tc.errContains != "" && len(result.Errors) > 0 {
+				assert.Contains(t, result.Errors[0], tc.errContains)
+			}
+			if tc.wantInfo > 0 {
+				assert.GreaterOrEqual(t, len(result.Info), tc.wantInfo)
+			}
+			if tc.infoContains != "" {
+				found := false
+				for _, info := range result.Info {
+					if containsStr(info, tc.infoContains) {
+						found = true
+						break
+					}
+				}
+				assert.True(t, found, "expected info containing %q", tc.infoContains)
+			}
+		})
+	}
+}
+
 // containsStr is a helper that checks if s contains substr.
 func containsStr(s, substr string) bool {
 	return len(s) >= len(substr) && (s == substr || len(substr) == 0 || findSubstr(s, substr))

--- a/builder/config.go
+++ b/builder/config.go
@@ -177,10 +177,33 @@ type ChangelogEntry struct {
 	Changes []string `yaml:"changes" json:"changes"`
 }
 
+// AMIFilterConfig specifies EC2 DescribeImages filters for dynamic AMI resolution.
+// Instead of hard-coding an AMI ID or SSM parameter ARN, users can specify filters
+// (owner, name pattern, architecture, etc.) and warpgate will automatically resolve
+// the latest matching AMI at build time.
+type AMIFilterConfig struct {
+	// Owners is a list of AWS account IDs or aliases (e.g., "amazon", "self") that own the AMI
+	Owners []string `yaml:"owners" json:"owners"`
+
+	// Filters is a map of EC2 DescribeImages filter names to values.
+	// Common filters: "name", "architecture", "state", "virtualization-type", "root-device-type".
+	// Values support wildcards (e.g., "kali-linux-2024.*").
+	Filters map[string]string `yaml:"filters" json:"filters"`
+
+	// MostRecent selects the most recently created AMI when multiple match.
+	// Defaults to true when not specified.
+	MostRecent *bool `yaml:"most_recent,omitempty" json:"most_recent,omitempty"`
+}
+
 // BaseImage specifies the base image to start from
 type BaseImage struct {
 	// Image is the base container image reference (e.g., "ubuntu:22.04", "alpine:latest")
 	Image string `yaml:"image" json:"image"`
+
+	// AMIFilters specifies filters for dynamically resolving an AMI using EC2 DescribeImages.
+	// When set, the latest matching AMI is used as the parent image for AMI builds.
+	// Mutually exclusive with Image for AMI targets.
+	AMIFilters *AMIFilterConfig `yaml:"ami_filters,omitempty" json:"ami_filters,omitempty"`
 
 	// Platform specifies the target platform (e.g., "linux/amd64", "linux/arm64")
 	Platform string `yaml:"platform,omitempty" json:"platform,omitempty"`

--- a/progress/progress.go
+++ b/progress/progress.go
@@ -474,7 +474,7 @@ func (d *Display) Close() {
 	defer d.mu.Unlock()
 
 	if d.ttyFile != nil {
-		d.ttyFile.Close()
+		_ = d.ttyFile.Close()
 		d.ttyFile = nil
 	}
 }

--- a/progress/terminal_unix.go
+++ b/progress/terminal_unix.go
@@ -41,7 +41,7 @@ func openTTY() *os.File {
 		return nil
 	}
 	if !term.IsTerminal(int(f.Fd())) {
-		f.Close()
+		_ = f.Close()
 		return nil
 	}
 	return f

--- a/schema/warpgate-template.json
+++ b/schema/warpgate-template.json
@@ -2,6 +2,35 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://warpgate.dev/schema/template.json",
   "$defs": {
+    "AMIFilterConfig": {
+      "properties": {
+        "owners": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "Owners is a list of AWS account IDs or aliases (e.g., \"amazon\", \"self\") that own the AMI"
+        },
+        "filters": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object",
+          "description": "Filters is a map of EC2 DescribeImages filter names to values.\nCommon filters: \"name\", \"architecture\", \"state\", \"virtualization-type\", \"root-device-type\".\nValues support wildcards (e.g., \"kali-linux-2024.*\")."
+        },
+        "most_recent": {
+          "type": "boolean",
+          "description": "MostRecent selects the most recently created AMI when multiple match.\nDefaults to true when not specified."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "owners",
+        "filters"
+      ],
+      "description": "AMIFilterConfig specifies EC2 DescribeImages filters for dynamic AMI resolution."
+    },
     "ArchOverride": {
       "properties": {
         "dockerfile": {
@@ -33,6 +62,10 @@
         "image": {
           "type": "string",
           "description": "Image is the base container image reference (e.g., \"ubuntu:22.04\", \"alpine:latest\")"
+        },
+        "ami_filters": {
+          "$ref": "#/$defs/AMIFilterConfig",
+          "description": "AMIFilters specifies filters for dynamically resolving an AMI using EC2 DescribeImages.\nWhen set, the latest matching AMI is used as the parent image for AMI builds.\nMutually exclusive with Image for AMI targets."
         },
         "platform": {
           "type": "string",

--- a/templates/config_validator.go
+++ b/templates/config_validator.go
@@ -62,21 +62,12 @@ func (v *Validator) ValidateWithOptions(ctx context.Context, config *builder.Con
 
 	// Check if this is a Dockerfile-based build
 	if config.IsDockerfileBased() {
-		// Validate Dockerfile configuration
 		if err := v.validateDockerfile(config.Dockerfile); err != nil {
 			return err
 		}
 	} else {
-		// Validate base image for provisioner-based builds
-		if config.Base.Image == "" {
-			return fmt.Errorf("config.base.image is required (or use dockerfile mode)")
-		}
-
-		// Validate provisioners
-		for i, prov := range config.Provisioners {
-			if err := v.validateProvisioner(ctx, &prov, i); err != nil {
-				return err
-			}
+		if err := v.validateProvisionerBuild(ctx, config); err != nil {
+			return err
 		}
 	}
 
@@ -257,6 +248,54 @@ func (v *Validator) hasUnresolvedVariable(path string) bool {
 	}
 
 	return false
+}
+
+// validateProvisionerBuild validates base image and provisioners for non-Dockerfile builds.
+func (v *Validator) validateProvisionerBuild(ctx context.Context, config *builder.Config) error {
+	if config.Base.Image == "" && config.Base.AMIFilters == nil {
+		return fmt.Errorf("config.base.image is required (or use ami_filters for AMI targets, or dockerfile mode)")
+	}
+
+	if config.Base.Image != "" && config.Base.AMIFilters != nil {
+		return fmt.Errorf("config.base.image and config.base.ami_filters are mutually exclusive")
+	}
+
+	if config.Base.AMIFilters != nil {
+		if err := v.validateAMIFilterTarget(config); err != nil {
+			return err
+		}
+		if err := v.validateAMIFilters(config.Base.AMIFilters); err != nil {
+			return err
+		}
+	}
+
+	for i, prov := range config.Provisioners {
+		if err := v.validateProvisioner(ctx, &prov, i); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// validateAMIFilterTarget checks that ami_filters is only used with at least one AMI target.
+func (v *Validator) validateAMIFilterTarget(config *builder.Config) error {
+	for _, t := range config.Targets {
+		if t.Type == "ami" {
+			return nil
+		}
+	}
+	return fmt.Errorf("config.base.ami_filters requires at least one AMI target")
+}
+
+// validateAMIFilters validates AMI filter configuration
+func (v *Validator) validateAMIFilters(filters *builder.AMIFilterConfig) error {
+	if len(filters.Owners) == 0 {
+		return fmt.Errorf("config.base.ami_filters.owners must specify at least one owner")
+	}
+	if len(filters.Filters) == 0 {
+		return fmt.Errorf("config.base.ami_filters.filters must specify at least one filter")
+	}
+	return nil
 }
 
 // validateTarget validates a single target

--- a/templates/config_validator_test.go
+++ b/templates/config_validator_test.go
@@ -487,6 +487,130 @@ func TestValidator_RequiredFields(t *testing.T) {
 	}
 }
 
+func TestValidator_AMIFilters(t *testing.T) {
+	validator := NewValidator()
+
+	tests := []struct {
+		name        string
+		config      *builder.Config
+		shouldError bool
+		errContains string
+	}{
+		{
+			name: "ami_filters with AMI target passes",
+			config: &builder.Config{
+				Name: "test",
+				Base: builder.BaseImage{
+					AMIFilters: &builder.AMIFilterConfig{
+						Owners:  []string{"679593333241"},
+						Filters: map[string]string{"name": "kali-*"},
+					},
+				},
+				Targets: []builder.Target{
+					{Type: "ami", Region: "us-east-1", AMIName: "test-ami"},
+				},
+			},
+			shouldError: false,
+		},
+		{
+			name: "both image and ami_filters errors",
+			config: &builder.Config{
+				Name: "test",
+				Base: builder.BaseImage{
+					Image: "ami-123",
+					AMIFilters: &builder.AMIFilterConfig{
+						Owners:  []string{"679593333241"},
+						Filters: map[string]string{"name": "kali-*"},
+					},
+				},
+				Targets: []builder.Target{
+					{Type: "ami", Region: "us-east-1", AMIName: "test-ami"},
+				},
+			},
+			shouldError: true,
+			errContains: "mutually exclusive",
+		},
+		{
+			name: "ami_filters without AMI target errors",
+			config: &builder.Config{
+				Name: "test",
+				Base: builder.BaseImage{
+					AMIFilters: &builder.AMIFilterConfig{
+						Owners:  []string{"679593333241"},
+						Filters: map[string]string{"name": "kali-*"},
+					},
+				},
+				Targets: []builder.Target{
+					{Type: "container", Platforms: []string{"linux/amd64"}},
+				},
+			},
+			shouldError: true,
+			errContains: "requires at least one AMI target",
+		},
+		{
+			name: "ami_filters with empty owners errors",
+			config: &builder.Config{
+				Name: "test",
+				Base: builder.BaseImage{
+					AMIFilters: &builder.AMIFilterConfig{
+						Owners:  []string{},
+						Filters: map[string]string{"name": "kali-*"},
+					},
+				},
+				Targets: []builder.Target{
+					{Type: "ami", Region: "us-east-1", AMIName: "test-ami"},
+				},
+			},
+			shouldError: true,
+			errContains: "at least one owner",
+		},
+		{
+			name: "ami_filters with empty filters errors",
+			config: &builder.Config{
+				Name: "test",
+				Base: builder.BaseImage{
+					AMIFilters: &builder.AMIFilterConfig{
+						Owners:  []string{"679593333241"},
+						Filters: map[string]string{},
+					},
+				},
+				Targets: []builder.Target{
+					{Type: "ami", Region: "us-east-1", AMIName: "test-ami"},
+				},
+			},
+			shouldError: true,
+			errContains: "at least one filter",
+		},
+		{
+			name: "neither image nor ami_filters errors",
+			config: &builder.Config{
+				Name: "test",
+				Base: builder.BaseImage{},
+				Targets: []builder.Target{
+					{Type: "ami", Region: "us-east-1", AMIName: "test-ami"},
+				},
+			},
+			shouldError: true,
+			errContains: "config.base.image is required",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validator.ValidateWithOptions(context.Background(), tt.config, ValidationOptions{SyntaxOnly: true})
+			if tt.shouldError {
+				if err == nil {
+					t.Errorf("expected error containing %q but got none", tt.errContains)
+				} else if tt.errContains != "" && !contains(err.Error(), tt.errContains) {
+					t.Errorf("expected error containing %q but got: %v", tt.errContains, err)
+				}
+			} else if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
 func TestValidator_ValidateDockerfile(t *testing.T) {
 	validator := NewValidator()
 	tmpDir := t.TempDir()


### PR DESCRIPTION

**Key Changes:**

- Introduced `ami_filters` config for dynamic AMI selection using EC2 DescribeImages
- Added `resolveAMIFilters` and `resolveParentImage` logic for AMI resolution
- Enhanced validation to support and dry-run AMI filter configs
- Provided comprehensive unit tests for AMI filter resolution and validation

**Added:**

- `AMIFilterConfig` struct to config for specifying EC2 DescribeImages filters and owners
- `resolveAMIFilters` and `resolveParentImage` methods to resolve latest matching AMI using filters or other sources
- `validateAMIFilters` function in validation logic to check filter correctness and preview match result
- Unit tests for AMI filter resolution (`TestResolveAMIFilters`, `TestResolveParentImage`) and filter validation (`TestValidateAMIFilters`)
- Validator logic to check mutual exclusivity, target compatibility, and filter requirements for `ami_filters` in config validation

**Changed:**

- `createImageRecipe` now uses unified `resolveParentImage` to handle direct AMI, SSM ARN, or filters
- Validation routines now accept and report on both direct AMI and filter-driven parent image configs
- `validateBasicConfig` and helper routines now accept both `base.image` and `base.ami_filters` as valid parent image sources
- Template config validator now supports and validates `ami_filters` semantics, including errors for misconfiguration

**Removed:**

- Redundant direct checks for `base.image` in validation in favor of unified image/filter handling
- Legacy validation logic that did not account for dynamic AMI resolution via filters