### PR TITLE
fix: rebuild image recipe when parent AMI changes

### DIFF
--- a/builder/ami/imagebuilder.go
+++ b/builder/ami/imagebuilder.go
@@ -810,8 +810,25 @@ func (b *ImageBuilder) getOrCreateImageRecipe(ctx context.Context, config builde
 	}
 
 	if existing != nil {
-		if b.forceRecreate {
-			logging.InfoContext(ctx, "Force recreate enabled, deleting existing image recipe: %s", *existing.Arn)
+		recreate := b.forceRecreate
+
+		// When AMI filters are configured, resolve the current parent image
+		// and compare with the cached recipe. The filter may now resolve to a
+		// different AMI (e.g. a newer snapshot), so the recipe must be rebuilt.
+		if !recreate && existing.ParentImage != nil {
+			currentParent, err := b.resolveParentImage(ctx, config)
+			if err != nil {
+				return "", fmt.Errorf("failed to resolve parent image for recipe comparison: %w", err)
+			}
+			if currentParent != *existing.ParentImage {
+				logging.InfoContext(ctx, "Parent image changed (%s -> %s), recreating image recipe",
+					*existing.ParentImage, currentParent)
+				recreate = true
+			}
+		}
+
+		if recreate {
+			logging.InfoContext(ctx, "Deleting existing image recipe: %s", *existing.Arn)
 			if err := b.resourceManager.DeleteImageRecipe(ctx, *existing.Arn); err != nil {
 				return "", fmt.Errorf("failed to delete existing image recipe: %w", err)
 			}

--- a/builder/ami/imagebuilder_test.go
+++ b/builder/ami/imagebuilder_test.go
@@ -2277,6 +2277,179 @@ func TestGetOrCreateImageRecipe_ExistingFound(t *testing.T) {
 	assert.Empty(t, created.RecipeARN)
 }
 
+func TestGetOrCreateImageRecipe_ParentImageChanged(t *testing.T) {
+	t.Parallel()
+
+	clients, mocks := newMockAWSClients()
+
+	// Existing recipe was built with ami-old-ubuntu
+	mocks.imageBuilder.ListImageRecipesFunc = func(ctx context.Context, params *imagebuilder.ListImageRecipesInput, optFns ...func(*imagebuilder.Options)) (*imagebuilder.ListImageRecipesOutput, error) {
+		return &imagebuilder.ListImageRecipesOutput{
+			ImageRecipeSummaryList: []ibtypes.ImageRecipeSummary{
+				{Name: aws.String("test-recipe"), Arn: aws.String("arn:recipe:existing")},
+			},
+		}, nil
+	}
+	mocks.imageBuilder.GetImageRecipeFunc = func(ctx context.Context, params *imagebuilder.GetImageRecipeInput, optFns ...func(*imagebuilder.Options)) (*imagebuilder.GetImageRecipeOutput, error) {
+		return &imagebuilder.GetImageRecipeOutput{
+			ImageRecipe: &ibtypes.ImageRecipe{
+				Arn:         aws.String("arn:recipe:existing"),
+				Name:        aws.String("test-recipe"),
+				ParentImage: aws.String("ami-old-ubuntu"),
+			},
+		}, nil
+	}
+
+	// Config now specifies a different direct AMI
+	deleteCalled := false
+	mocks.imageBuilder.DeleteImageRecipeFunc = func(ctx context.Context, params *imagebuilder.DeleteImageRecipeInput, optFns ...func(*imagebuilder.Options)) (*imagebuilder.DeleteImageRecipeOutput, error) {
+		deleteCalled = true
+		return &imagebuilder.DeleteImageRecipeOutput{}, nil
+	}
+	mocks.imageBuilder.CreateImageRecipeFunc = func(ctx context.Context, params *imagebuilder.CreateImageRecipeInput, optFns ...func(*imagebuilder.Options)) (*imagebuilder.CreateImageRecipeOutput, error) {
+		assert.Equal(t, "ami-new-kali", *params.ParentImage)
+		return &imagebuilder.CreateImageRecipeOutput{
+			ImageRecipeArn: aws.String("arn:recipe:new"),
+		}, nil
+	}
+
+	ib := &ImageBuilder{
+		clients:         clients,
+		globalConfig:    newTestGlobalConfig(),
+		resourceManager: NewResourceManager(clients),
+		config:          ClientConfig{Region: "us-east-1"},
+		forceRecreate:   false,
+	}
+
+	created := &CreatedResources{}
+	arn, err := ib.getOrCreateImageRecipe(context.Background(), builder.Config{
+		Name:    "test",
+		Version: "1.0.0",
+		Base:    builder.BaseImage{Image: "ami-new-kali"},
+	}, []string{"arn:comp1"}, &builder.Target{Region: "us-east-1"}, created)
+	require.NoError(t, err)
+	assert.True(t, deleteCalled, "should delete old recipe when parent image changed")
+	assert.Equal(t, "arn:recipe:new", arn)
+	assert.Equal(t, "arn:recipe:new", created.RecipeARN)
+}
+
+func TestGetOrCreateImageRecipe_ParentImageChangedWithAMIFilters(t *testing.T) {
+	t.Parallel()
+
+	clients, mocks := newMockAWSClients()
+
+	// Existing recipe was built with ami-old-ubuntu
+	mocks.imageBuilder.ListImageRecipesFunc = func(ctx context.Context, params *imagebuilder.ListImageRecipesInput, optFns ...func(*imagebuilder.Options)) (*imagebuilder.ListImageRecipesOutput, error) {
+		return &imagebuilder.ListImageRecipesOutput{
+			ImageRecipeSummaryList: []ibtypes.ImageRecipeSummary{
+				{Name: aws.String("test-recipe"), Arn: aws.String("arn:recipe:existing")},
+			},
+		}, nil
+	}
+	mocks.imageBuilder.GetImageRecipeFunc = func(ctx context.Context, params *imagebuilder.GetImageRecipeInput, optFns ...func(*imagebuilder.Options)) (*imagebuilder.GetImageRecipeOutput, error) {
+		return &imagebuilder.GetImageRecipeOutput{
+			ImageRecipe: &ibtypes.ImageRecipe{
+				Arn:         aws.String("arn:recipe:existing"),
+				Name:        aws.String("test-recipe"),
+				ParentImage: aws.String("ami-old-ubuntu"),
+			},
+		}, nil
+	}
+
+	// AMI filter now resolves to a different AMI
+	mocks.ec2.DescribeImagesFunc = func(ctx context.Context, params *ec2.DescribeImagesInput, optFns ...func(*ec2.Options)) (*ec2.DescribeImagesOutput, error) {
+		return &ec2.DescribeImagesOutput{
+			Images: []ec2types.Image{
+				{
+					ImageId:      aws.String("ami-new-kali"),
+					CreationDate: aws.String("2026-04-12T00:00:00.000Z"),
+					Name:         aws.String("kali-2026.1"),
+				},
+			},
+		}, nil
+	}
+
+	deleteCalled := false
+	mocks.imageBuilder.DeleteImageRecipeFunc = func(ctx context.Context, params *imagebuilder.DeleteImageRecipeInput, optFns ...func(*imagebuilder.Options)) (*imagebuilder.DeleteImageRecipeOutput, error) {
+		deleteCalled = true
+		return &imagebuilder.DeleteImageRecipeOutput{}, nil
+	}
+	mocks.imageBuilder.CreateImageRecipeFunc = func(ctx context.Context, params *imagebuilder.CreateImageRecipeInput, optFns ...func(*imagebuilder.Options)) (*imagebuilder.CreateImageRecipeOutput, error) {
+		assert.Equal(t, "ami-new-kali", *params.ParentImage)
+		return &imagebuilder.CreateImageRecipeOutput{
+			ImageRecipeArn: aws.String("arn:recipe:new"),
+		}, nil
+	}
+
+	mostRecent := true
+	ib := &ImageBuilder{
+		clients:         clients,
+		globalConfig:    newTestGlobalConfig(),
+		resourceManager: NewResourceManager(clients),
+		config:          ClientConfig{Region: "us-east-1"},
+		forceRecreate:   false,
+	}
+
+	created := &CreatedResources{}
+	arn, err := ib.getOrCreateImageRecipe(context.Background(), builder.Config{
+		Name:    "test",
+		Version: "1.0.0",
+		Base: builder.BaseImage{
+			AMIFilters: &builder.AMIFilterConfig{
+				Owners:     []string{"123456789012"},
+				Filters:    map[string]string{"name": "kali-*"},
+				MostRecent: &mostRecent,
+			},
+		},
+	}, []string{"arn:comp1"}, &builder.Target{Region: "us-east-1"}, created)
+	require.NoError(t, err)
+	assert.True(t, deleteCalled, "should delete old recipe when AMI filter resolves to different parent")
+	assert.Equal(t, "arn:recipe:new", arn)
+	assert.Equal(t, "arn:recipe:new", created.RecipeARN)
+}
+
+func TestGetOrCreateImageRecipe_ParentImageUnchanged(t *testing.T) {
+	t.Parallel()
+
+	clients, mocks := newMockAWSClients()
+
+	// Existing recipe matches current parent image — should be reused
+	mocks.imageBuilder.ListImageRecipesFunc = func(ctx context.Context, params *imagebuilder.ListImageRecipesInput, optFns ...func(*imagebuilder.Options)) (*imagebuilder.ListImageRecipesOutput, error) {
+		return &imagebuilder.ListImageRecipesOutput{
+			ImageRecipeSummaryList: []ibtypes.ImageRecipeSummary{
+				{Name: aws.String("test-recipe"), Arn: aws.String("arn:recipe:existing")},
+			},
+		}, nil
+	}
+	mocks.imageBuilder.GetImageRecipeFunc = func(ctx context.Context, params *imagebuilder.GetImageRecipeInput, optFns ...func(*imagebuilder.Options)) (*imagebuilder.GetImageRecipeOutput, error) {
+		return &imagebuilder.GetImageRecipeOutput{
+			ImageRecipe: &ibtypes.ImageRecipe{
+				Arn:         aws.String("arn:recipe:existing"),
+				Name:        aws.String("test-recipe"),
+				ParentImage: aws.String("ami-base"),
+			},
+		}, nil
+	}
+
+	ib := &ImageBuilder{
+		clients:         clients,
+		globalConfig:    newTestGlobalConfig(),
+		resourceManager: NewResourceManager(clients),
+		config:          ClientConfig{Region: "us-east-1"},
+		forceRecreate:   false,
+	}
+
+	created := &CreatedResources{}
+	arn, err := ib.getOrCreateImageRecipe(context.Background(), builder.Config{
+		Name:    "test",
+		Version: "1.0.0",
+		Base:    builder.BaseImage{Image: "ami-base"},
+	}, []string{"arn:comp1"}, &builder.Target{Region: "us-east-1"}, created)
+	require.NoError(t, err)
+	assert.Equal(t, "arn:recipe:existing", arn, "should reuse recipe when parent image unchanged")
+	assert.Empty(t, created.RecipeARN, "should not set created recipe ARN when reusing")
+}
+
 func TestGetOrCreateImageRecipe_ForceRecreate(t *testing.T) {
 	t.Parallel()
 

--- a/builder/ami/imagebuilder_test.go
+++ b/builder/ami/imagebuilder_test.go
@@ -2450,6 +2450,100 @@ func TestGetOrCreateImageRecipe_ParentImageUnchanged(t *testing.T) {
 	assert.Empty(t, created.RecipeARN, "should not set created recipe ARN when reusing")
 }
 
+func TestGetOrCreateImageRecipe_ResolveParentImageError(t *testing.T) {
+	t.Parallel()
+
+	clients, mocks := newMockAWSClients()
+
+	mocks.imageBuilder.ListImageRecipesFunc = func(ctx context.Context, params *imagebuilder.ListImageRecipesInput, optFns ...func(*imagebuilder.Options)) (*imagebuilder.ListImageRecipesOutput, error) {
+		return &imagebuilder.ListImageRecipesOutput{
+			ImageRecipeSummaryList: []ibtypes.ImageRecipeSummary{
+				{Name: aws.String("test-recipe"), Arn: aws.String("arn:recipe:existing")},
+			},
+		}, nil
+	}
+	mocks.imageBuilder.GetImageRecipeFunc = func(ctx context.Context, params *imagebuilder.GetImageRecipeInput, optFns ...func(*imagebuilder.Options)) (*imagebuilder.GetImageRecipeOutput, error) {
+		return &imagebuilder.GetImageRecipeOutput{
+			ImageRecipe: &ibtypes.ImageRecipe{
+				Arn:         aws.String("arn:recipe:existing"),
+				Name:        aws.String("test-recipe"),
+				ParentImage: aws.String("ami-old"),
+			},
+		}, nil
+	}
+
+	// DescribeImages fails, causing resolveParentImage to error
+	mocks.ec2.DescribeImagesFunc = func(ctx context.Context, params *ec2.DescribeImagesInput, optFns ...func(*ec2.Options)) (*ec2.DescribeImagesOutput, error) {
+		return nil, fmt.Errorf("ec2 api error")
+	}
+
+	ib := &ImageBuilder{
+		clients:         clients,
+		globalConfig:    newTestGlobalConfig(),
+		resourceManager: NewResourceManager(clients),
+		config:          ClientConfig{Region: "us-east-1"},
+		forceRecreate:   false,
+	}
+
+	created := &CreatedResources{}
+	mostRecent := true
+	_, err := ib.getOrCreateImageRecipe(context.Background(), builder.Config{
+		Name:    "test",
+		Version: "1.0.0",
+		Base: builder.BaseImage{
+			AMIFilters: &builder.AMIFilterConfig{
+				Owners:     []string{"123456789012"},
+				Filters:    map[string]string{"name": "kali-*"},
+				MostRecent: &mostRecent,
+			},
+		},
+	}, []string{"arn:comp1"}, &builder.Target{Region: "us-east-1"}, created)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to resolve parent image for recipe comparison")
+}
+
+func TestGetOrCreateImageRecipe_NilParentImageSkipsComparison(t *testing.T) {
+	t.Parallel()
+
+	clients, mocks := newMockAWSClients()
+
+	// Existing recipe has no ParentImage set — should skip comparison and reuse
+	mocks.imageBuilder.ListImageRecipesFunc = func(ctx context.Context, params *imagebuilder.ListImageRecipesInput, optFns ...func(*imagebuilder.Options)) (*imagebuilder.ListImageRecipesOutput, error) {
+		return &imagebuilder.ListImageRecipesOutput{
+			ImageRecipeSummaryList: []ibtypes.ImageRecipeSummary{
+				{Name: aws.String("test-recipe"), Arn: aws.String("arn:recipe:existing")},
+			},
+		}, nil
+	}
+	mocks.imageBuilder.GetImageRecipeFunc = func(ctx context.Context, params *imagebuilder.GetImageRecipeInput, optFns ...func(*imagebuilder.Options)) (*imagebuilder.GetImageRecipeOutput, error) {
+		return &imagebuilder.GetImageRecipeOutput{
+			ImageRecipe: &ibtypes.ImageRecipe{
+				Arn:         aws.String("arn:recipe:existing"),
+				Name:        aws.String("test-recipe"),
+				ParentImage: nil,
+			},
+		}, nil
+	}
+
+	ib := &ImageBuilder{
+		clients:         clients,
+		globalConfig:    newTestGlobalConfig(),
+		resourceManager: NewResourceManager(clients),
+		config:          ClientConfig{Region: "us-east-1"},
+		forceRecreate:   false,
+	}
+
+	created := &CreatedResources{}
+	arn, err := ib.getOrCreateImageRecipe(context.Background(), builder.Config{
+		Name:    "test",
+		Version: "1.0.0",
+		Base:    builder.BaseImage{Image: "ami-something"},
+	}, []string{"arn:comp1"}, &builder.Target{Region: "us-east-1"}, created)
+	require.NoError(t, err)
+	assert.Equal(t, "arn:recipe:existing", arn, "should reuse recipe when ParentImage is nil")
+	assert.Empty(t, created.RecipeARN)
+}
+
 func TestGetOrCreateImageRecipe_ForceRecreate(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION

**Key Changes:**

- Automatically detect and recreate image recipes if the parent AMI changes
- Ensure AMI filter-based recipes are updated when the resolved AMI differs
- Added tests to cover parent image change and reuse scenarios

**Added:**

- Test cases for parent AMI changes, including:
  - Rebuilding the recipe when a direct AMI changes
  - Rebuilding when AMI filter resolves to a new image
  - Ensuring no rebuild occurs if the parent AMI is unchanged

**Changed:**

- Image recipe creation logic:
  - Added comparison between the currently resolved parent AMI and the
    existing recipe's parent image
  - Trigger recipe deletion and recreation if the parent AMI differs,
    even if forceRecreate is not set
  - Improved logging to clarify when and why recipes are deleted or reused

**Removed:**

- No code or tests were removed in this change