### PR TITLE
test: ensure thread-safe counters in concurrent tests using atomic package

### DIFF
--- a/builder/service_test.go
+++ b/builder/service_test.go
@@ -27,6 +27,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/cowdogmoo/warpgate/v3/config"
@@ -855,11 +856,11 @@ func TestPush_MultipleResults(t *testing.T) {
 	t.Parallel()
 	cfg := &config.Config{}
 
-	pushCount := 0
+	var pushCount atomic.Int32
 	buildKitCreator := func(ctx context.Context) (ContainerBuilder, error) {
 		return &mockContainerBuilder{
 			pushFunc: func(ctx context.Context, imageRef, registry string) (string, error) {
-				pushCount++
+				pushCount.Add(1)
 				return "sha256:abcdef", nil
 			},
 		}, nil
@@ -936,11 +937,11 @@ func TestExecuteContainerBuild_MultiArch(t *testing.T) {
 	t.Parallel()
 	cfg := &config.Config{}
 
-	buildCount := 0
+	var buildCount atomic.Int32
 	buildKitCreator := func(ctx context.Context) (ContainerBuilder, error) {
 		return &mockContainerBuilder{
 			buildFunc: func(ctx context.Context, cfg Config) (*BuildResult, error) {
-				buildCount++
+				buildCount.Add(1)
 				return &BuildResult{
 					ImageRef:     fmt.Sprintf("test:%s", cfg.Base.Platform),
 					Architecture: cfg.Architectures[0],


### PR DESCRIPTION
**Key Changes:**

- Replaced non-atomic integer counters with atomic.Int32 for thread safety
- Updated push and build count increments to use atomic operations
- Improved reliability of tests that run in parallel by preventing race conditions

**Changed:**

- Switched pushCount and buildCount from plain integers to atomic.Int32 in
  concurrent test cases to avoid race conditions
- Updated all increment operations on these counters to use atomic.Add(1)
  instead of direct increment, ensuring thread-safe counter manipulation in
  parallel test execution