### PR TITLE
fix: enforce secure buildkit tcp connections and improve temp file handling

### DIFF
--- a/builder/buildkit/buildkit.go
+++ b/builder/buildkit/buildkit.go
@@ -116,25 +116,9 @@ func NewBuildKitBuilder(ctx context.Context) (*BuildKitBuilder, error) {
 		logging.InfoContext(ctx, "Auto-detected BuildKit builder: %s", containerName)
 	}
 
-	clientOpts := []client.ClientOpt{}
-
-	if strings.HasPrefix(addr, "tcp://") && cfg.BuildKit.TLSEnabled {
-		tlsConfig, err := loadTLSConfig(cfg.BuildKit)
-		if err != nil {
-			return nil, errors.Wrap("load TLS config", "", err)
-		}
-		clientOpts = append(clientOpts, client.WithGRPCDialOption(
-			grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig)),
-		))
-		logging.InfoContext(ctx, "TLS enabled for BuildKit connection")
-	} else if strings.HasPrefix(addr, "tcp://") {
-		if err := validateTCPSecurity(); err != nil {
-			return nil, err
-		}
-		clientOpts = append(clientOpts, client.WithGRPCDialOption(
-			grpc.WithTransportCredentials(insecure.NewCredentials()),
-		))
-		logging.WarnContext(ctx, "Connecting to BuildKit without TLS (insecure) — BUILDKIT_INSECURE_NO_TLS override active")
+	clientOpts, err := buildClientOpts(ctx, addr, cfg.BuildKit)
+	if err != nil {
+		return nil, err
 	}
 
 	c, err := client.New(ctx, addr, clientOpts...)
@@ -173,6 +157,33 @@ func NewBuildKitBuilder(ctx context.Context) (*BuildKitBuilder, error) {
 	}, nil
 }
 
+// buildClientOpts returns the gRPC client options for the given address and
+// BuildKit configuration, enforcing TLS policy for TCP connections.
+func buildClientOpts(ctx context.Context, addr string, cfg config.BuildKitConfig) ([]client.ClientOpt, error) {
+	var opts []client.ClientOpt
+
+	if strings.HasPrefix(addr, "tcp://") && cfg.TLSEnabled {
+		tlsConfig, err := loadTLSConfig(cfg)
+		if err != nil {
+			return nil, errors.Wrap("load TLS config", "", err)
+		}
+		opts = append(opts, client.WithGRPCDialOption(
+			grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig)),
+		))
+		logging.InfoContext(ctx, "TLS enabled for BuildKit connection")
+	} else if strings.HasPrefix(addr, "tcp://") {
+		if err := validateTCPSecurity(); err != nil {
+			return nil, err
+		}
+		opts = append(opts, client.WithGRPCDialOption(
+			grpc.WithTransportCredentials(insecure.NewCredentials()),
+		))
+		logging.WarnContext(ctx, "Connecting to BuildKit without TLS (insecure) — BUILDKIT_INSECURE_NO_TLS override active")
+	}
+
+	return opts, nil
+}
+
 // validateTCPSecurity checks that plaintext TCP connections are explicitly
 // opted-in via the BUILDKIT_INSECURE_NO_TLS environment variable.
 func validateTCPSecurity() error {
@@ -181,20 +192,6 @@ func validateTCPSecurity() error {
 			"set buildkit.tls_enabled=true in config or set BUILDKIT_INSECURE_NO_TLS=1 to override")
 	}
 	return nil
-}
-
-// createTempImageTar creates a temporary file for storing an image tar export.
-// The caller is responsible for removing the file when done.
-func createTempImageTar() (string, error) {
-	tmpFile, err := os.CreateTemp("", "warpgate-image-*.tar")
-	if err != nil {
-		return "", fmt.Errorf("failed to create temporary image tar: %w", err)
-	}
-	path := tmpFile.Name()
-	if err := tmpFile.Close(); err != nil {
-		return "", fmt.Errorf("failed to close temporary image tar: %w", err)
-	}
-	return path, nil
 }
 
 // loadTLSConfig creates a TLS configuration for secure BuildKit connections.
@@ -1227,10 +1224,7 @@ func (b *BuildKitBuilder) Build(ctx context.Context, cfg builder.Config) (*build
 		imageName = fmt.Sprintf("%s/%s", cfg.Registry, imageName)
 	}
 
-	imageTarPath, err := createTempImageTar()
-	if err != nil {
-		return nil, err
-	}
+	imageTarPath := filepath.Join(os.TempDir(), fmt.Sprintf("warpgate-image-%d.tar", time.Now().Unix()))
 	defer func() {
 		if err := os.Remove(imageTarPath); err != nil {
 			logging.WarnContext(ctx, "Failed to remove temporary image tar: %v", err)
@@ -1850,10 +1844,7 @@ func (b *BuildKitBuilder) BuildDockerfile(ctx context.Context, cfg builder.Confi
 		frontendAttrs["no-cache"] = ""
 	}
 
-	imageTarPath, err := createTempImageTar()
-	if err != nil {
-		return nil, err
-	}
+	imageTarPath := filepath.Join(os.TempDir(), fmt.Sprintf("warpgate-image-%d.tar", time.Now().Unix()))
 	defer func() {
 		if err := os.Remove(imageTarPath); err != nil {
 			logging.WarnContext(ctx, "Failed to remove temporary image tar: %v", err)

--- a/builder/buildkit/buildkit.go
+++ b/builder/buildkit/buildkit.go
@@ -128,10 +128,17 @@ func NewBuildKitBuilder(ctx context.Context) (*BuildKitBuilder, error) {
 		))
 		logging.InfoContext(ctx, "TLS enabled for BuildKit connection")
 	} else if strings.HasPrefix(addr, "tcp://") {
+		// Plaintext TCP is only permitted when explicitly opted-in via the
+		// BUILDKIT_INSECURE_NO_TLS environment variable.  In all other cases
+		// callers should set buildkit.tls_enabled=true in the config.
+		if os.Getenv("BUILDKIT_INSECURE_NO_TLS") != "1" {
+			return nil, fmt.Errorf("connecting to BuildKit over TCP without TLS is not allowed; " +
+				"set buildkit.tls_enabled=true in config or set BUILDKIT_INSECURE_NO_TLS=1 to override")
+		}
 		clientOpts = append(clientOpts, client.WithGRPCDialOption(
 			grpc.WithTransportCredentials(insecure.NewCredentials()),
 		))
-		logging.WarnContext(ctx, "Connecting to BuildKit without TLS (insecure)")
+		logging.WarnContext(ctx, "Connecting to BuildKit without TLS (insecure) — BUILDKIT_INSECURE_NO_TLS override active")
 	}
 
 	c, err := client.New(ctx, addr, clientOpts...)
@@ -469,7 +476,7 @@ func (b *BuildKitBuilder) applyShellProvisioner(state llb.State, prov builder.Pr
 	combinedCmd := strings.Join(prov.Inline, " && ")
 
 	runOpts := []llb.RunOption{
-		llb.Shlex(fmt.Sprintf("sh -c '%s'", combinedCmd)),
+		llb.Args([]string{"sh", "-c", combinedCmd}),
 	}
 
 	if strings.Contains(combinedCmd, "apt-get") {
@@ -587,7 +594,7 @@ func (b *BuildKitBuilder) applyFileProvisioner(state llb.State, prov builder.Pro
 
 	if prov.Mode != "" {
 		state = state.Run(
-			llb.Shlexf("chmod %s %s", prov.Mode, prov.Destination),
+			llb.Args([]string{"chmod", prov.Mode, prov.Destination}),
 		).Root()
 	}
 
@@ -616,7 +623,7 @@ func (b *BuildKitBuilder) applyScriptProvisioner(state llb.State, prov builder.P
 		)
 
 		state = state.Run(
-			llb.Shlexf("chmod +x %s && %s", destPath, destPath),
+			llb.Args([]string{"sh", "-c", "chmod +x " + destPath + " && " + destPath}),
 		).Root()
 	}
 
@@ -645,7 +652,7 @@ func (b *BuildKitBuilder) applyPowerShellProvisioner(state llb.State, prov build
 		)
 
 		state = state.Run(
-			llb.Shlexf("pwsh -ExecutionPolicy Bypass -File %s", destPath),
+			llb.Args([]string{"pwsh", "-ExecutionPolicy", "Bypass", "-File", destPath}),
 		).Root()
 	}
 
@@ -709,13 +716,13 @@ func (b *BuildKitBuilder) applyAnsibleProvisioner(state llb.State, prov builder.
 		).Root()
 	}
 
-	cmd := "ansible-playbook /tmp/playbook.yml -i localhost, -c local"
+	ansibleArgs := []string{"ansible-playbook", "/tmp/playbook.yml", "-i", "localhost,", "-c", "local"}
 	for key, value := range prov.ExtraVars {
-		cmd += fmt.Sprintf(" -e %s=%s", key, value)
+		ansibleArgs = append(ansibleArgs, "-e", key+"="+value)
 	}
 
 	runOpts := []llb.RunOption{
-		llb.Shlex(cmd),
+		llb.Args(ansibleArgs),
 		llb.AddMount("/var/cache/apt", llb.Scratch(),
 			llb.AsPersistentCacheDir("warpgate-apt-cache", llb.CacheMountShared)),
 		llb.AddMount("/var/lib/apt/lists", llb.Scratch(),
@@ -1200,7 +1207,14 @@ func (b *BuildKitBuilder) Build(ctx context.Context, cfg builder.Config) (*build
 		imageName = fmt.Sprintf("%s/%s", cfg.Registry, imageName)
 	}
 
-	imageTarPath := filepath.Join(os.TempDir(), fmt.Sprintf("warpgate-image-%d.tar", time.Now().Unix()))
+	tmpFile, err := os.CreateTemp("", "warpgate-image-*.tar")
+	if err != nil {
+		return nil, fmt.Errorf("failed to create temporary image tar: %w", err)
+	}
+	imageTarPath := tmpFile.Name()
+	if err := tmpFile.Close(); err != nil {
+		return nil, fmt.Errorf("failed to close temporary image tar: %w", err)
+	}
 	defer func() {
 		if err := os.Remove(imageTarPath); err != nil {
 			logging.WarnContext(ctx, "Failed to remove temporary image tar: %v", err)
@@ -1820,7 +1834,14 @@ func (b *BuildKitBuilder) BuildDockerfile(ctx context.Context, cfg builder.Confi
 		frontendAttrs["no-cache"] = ""
 	}
 
-	imageTarPath := filepath.Join(os.TempDir(), fmt.Sprintf("warpgate-image-%d.tar", time.Now().Unix()))
+	tmpFile, err := os.CreateTemp("", "warpgate-image-*.tar")
+	if err != nil {
+		return nil, fmt.Errorf("failed to create temporary image tar: %w", err)
+	}
+	imageTarPath := tmpFile.Name()
+	if err := tmpFile.Close(); err != nil {
+		return nil, fmt.Errorf("failed to close temporary image tar: %w", err)
+	}
 	defer func() {
 		if err := os.Remove(imageTarPath); err != nil {
 			logging.WarnContext(ctx, "Failed to remove temporary image tar: %v", err)

--- a/builder/buildkit/buildkit.go
+++ b/builder/buildkit/buildkit.go
@@ -128,12 +128,8 @@ func NewBuildKitBuilder(ctx context.Context) (*BuildKitBuilder, error) {
 		))
 		logging.InfoContext(ctx, "TLS enabled for BuildKit connection")
 	} else if strings.HasPrefix(addr, "tcp://") {
-		// Plaintext TCP is only permitted when explicitly opted-in via the
-		// BUILDKIT_INSECURE_NO_TLS environment variable.  In all other cases
-		// callers should set buildkit.tls_enabled=true in the config.
-		if os.Getenv("BUILDKIT_INSECURE_NO_TLS") != "1" {
-			return nil, fmt.Errorf("connecting to BuildKit over TCP without TLS is not allowed; " +
-				"set buildkit.tls_enabled=true in config or set BUILDKIT_INSECURE_NO_TLS=1 to override")
+		if err := validateTCPSecurity(); err != nil {
+			return nil, err
 		}
 		clientOpts = append(clientOpts, client.WithGRPCDialOption(
 			grpc.WithTransportCredentials(insecure.NewCredentials()),
@@ -175,6 +171,30 @@ func NewBuildKitBuilder(ctx context.Context) (*BuildKitBuilder, error) {
 		cacheFrom:     []string{},
 		cacheTo:       []string{},
 	}, nil
+}
+
+// validateTCPSecurity checks that plaintext TCP connections are explicitly
+// opted-in via the BUILDKIT_INSECURE_NO_TLS environment variable.
+func validateTCPSecurity() error {
+	if os.Getenv("BUILDKIT_INSECURE_NO_TLS") != "1" {
+		return fmt.Errorf("connecting to BuildKit over TCP without TLS is not allowed; " +
+			"set buildkit.tls_enabled=true in config or set BUILDKIT_INSECURE_NO_TLS=1 to override")
+	}
+	return nil
+}
+
+// createTempImageTar creates a temporary file for storing an image tar export.
+// The caller is responsible for removing the file when done.
+func createTempImageTar() (string, error) {
+	tmpFile, err := os.CreateTemp("", "warpgate-image-*.tar")
+	if err != nil {
+		return "", fmt.Errorf("failed to create temporary image tar: %w", err)
+	}
+	path := tmpFile.Name()
+	if err := tmpFile.Close(); err != nil {
+		return "", fmt.Errorf("failed to close temporary image tar: %w", err)
+	}
+	return path, nil
 }
 
 // loadTLSConfig creates a TLS configuration for secure BuildKit connections.
@@ -1207,13 +1227,9 @@ func (b *BuildKitBuilder) Build(ctx context.Context, cfg builder.Config) (*build
 		imageName = fmt.Sprintf("%s/%s", cfg.Registry, imageName)
 	}
 
-	tmpFile, err := os.CreateTemp("", "warpgate-image-*.tar")
+	imageTarPath, err := createTempImageTar()
 	if err != nil {
-		return nil, fmt.Errorf("failed to create temporary image tar: %w", err)
-	}
-	imageTarPath := tmpFile.Name()
-	if err := tmpFile.Close(); err != nil {
-		return nil, fmt.Errorf("failed to close temporary image tar: %w", err)
+		return nil, err
 	}
 	defer func() {
 		if err := os.Remove(imageTarPath); err != nil {
@@ -1834,13 +1850,9 @@ func (b *BuildKitBuilder) BuildDockerfile(ctx context.Context, cfg builder.Confi
 		frontendAttrs["no-cache"] = ""
 	}
 
-	tmpFile, err := os.CreateTemp("", "warpgate-image-*.tar")
+	imageTarPath, err := createTempImageTar()
 	if err != nil {
-		return nil, fmt.Errorf("failed to create temporary image tar: %w", err)
-	}
-	imageTarPath := tmpFile.Name()
-	if err := tmpFile.Close(); err != nil {
-		return nil, fmt.Errorf("failed to close temporary image tar: %w", err)
+		return nil, err
 	}
 	defer func() {
 		if err := os.Remove(imageTarPath); err != nil {

--- a/builder/buildkit/buildkit_test.go
+++ b/builder/buildkit/buildkit_test.go
@@ -7720,6 +7720,56 @@ func TestApplyPlatformFix_LLBArchFallback(t *testing.T) {
 	}
 }
 
+func TestValidateTCPSecurity(t *testing.T) {
+	tests := []struct {
+		name        string
+		envValue    string
+		expectError bool
+	}{
+		{"blocked when env not set", "", true},
+		{"blocked when env is 0", "0", true},
+		{"blocked when env is yes", "yes", true},
+		{"allowed when env is 1", "1", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.envValue != "" {
+				t.Setenv("BUILDKIT_INSECURE_NO_TLS", tt.envValue)
+			}
+			err := validateTCPSecurity()
+			if (err != nil) != tt.expectError {
+				t.Errorf("validateTCPSecurity() error = %v, expectError = %v", err, tt.expectError)
+			}
+			if err != nil && !strings.Contains(err.Error(), "TCP without TLS is not allowed") {
+				t.Errorf("unexpected error message: %v", err)
+			}
+		})
+	}
+}
+
+func TestCreateTempImageTar(t *testing.T) {
+	path, err := createTempImageTar()
+	if err != nil {
+		t.Fatalf("createTempImageTar() unexpected error: %v", err)
+	}
+	defer os.Remove(path)
+
+	if !strings.HasPrefix(filepath.Base(path), "warpgate-image-") {
+		t.Errorf("expected temp file name to start with warpgate-image-, got %s", filepath.Base(path))
+	}
+	if !strings.HasSuffix(path, ".tar") {
+		t.Errorf("expected temp file name to end with .tar, got %s", path)
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("temp file does not exist: %v", err)
+	}
+	if info.IsDir() {
+		t.Error("expected a file, got a directory")
+	}
+}
+
 func TestApplyPlatformFix_PropagatesError(t *testing.T) {
 	origLoad := daemonLoad
 	defer func() { daemonLoad = origLoad }()

--- a/builder/buildkit/buildkit_test.go
+++ b/builder/buildkit/buildkit_test.go
@@ -7747,27 +7747,87 @@ func TestValidateTCPSecurity(t *testing.T) {
 	}
 }
 
-func TestCreateTempImageTar(t *testing.T) {
-	path, err := createTempImageTar()
-	if err != nil {
-		t.Fatalf("createTempImageTar() unexpected error: %v", err)
-	}
-	defer os.Remove(path)
+func TestBuildClientOpts(t *testing.T) {
+	t.Run("unix socket returns empty opts", func(t *testing.T) {
+		opts, err := buildClientOpts(context.Background(), "unix:///run/buildkit/buildkitd.sock", config.BuildKitConfig{})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(opts) != 0 {
+			t.Errorf("expected no opts for unix socket, got %d", len(opts))
+		}
+	})
 
-	if !strings.HasPrefix(filepath.Base(path), "warpgate-image-") {
-		t.Errorf("expected temp file name to start with warpgate-image-, got %s", filepath.Base(path))
-	}
-	if !strings.HasSuffix(path, ".tar") {
-		t.Errorf("expected temp file name to end with .tar, got %s", path)
-	}
+	t.Run("docker-container returns empty opts", func(t *testing.T) {
+		opts, err := buildClientOpts(context.Background(), "docker-container://mybuilder", config.BuildKitConfig{})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(opts) != 0 {
+			t.Errorf("expected no opts for docker-container, got %d", len(opts))
+		}
+	})
 
-	info, err := os.Stat(path)
-	if err != nil {
-		t.Fatalf("temp file does not exist: %v", err)
-	}
-	if info.IsDir() {
-		t.Error("expected a file, got a directory")
-	}
+	t.Run("tcp without TLS blocked by default", func(t *testing.T) {
+		_, err := buildClientOpts(context.Background(), "tcp://10.0.0.1:1234", config.BuildKitConfig{})
+		if err == nil {
+			t.Fatal("expected error for TCP without TLS")
+		}
+		if !strings.Contains(err.Error(), "TCP without TLS is not allowed") {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("tcp without TLS allowed with env override", func(t *testing.T) {
+		t.Setenv("BUILDKIT_INSECURE_NO_TLS", "1")
+		opts, err := buildClientOpts(context.Background(), "tcp://10.0.0.1:1234", config.BuildKitConfig{})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(opts) != 1 {
+			t.Errorf("expected 1 opt (grpc dial option), got %d", len(opts))
+		}
+	})
+
+	t.Run("tcp with TLS uses TLS credentials", func(t *testing.T) {
+		certDir := t.TempDir()
+		caKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+		caTemplate := &x509.Certificate{
+			SerialNumber:          big.NewInt(1),
+			Subject:               pkix.Name{CommonName: "test-ca"},
+			NotBefore:             time.Now(),
+			NotAfter:              time.Now().Add(time.Hour),
+			IsCA:                  true,
+			BasicConstraintsValid: true,
+		}
+		caDER, _ := x509.CreateCertificate(rand.Reader, caTemplate, caTemplate, &caKey.PublicKey, caKey)
+		caCertPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: caDER})
+		caPath := filepath.Join(certDir, "ca.pem")
+		if err := os.WriteFile(caPath, caCertPEM, 0600); err != nil {
+			t.Fatalf("failed to write CA cert: %v", err)
+		}
+
+		opts, err := buildClientOpts(context.Background(), "tcp://10.0.0.1:1234", config.BuildKitConfig{
+			TLSEnabled: true,
+			TLSCACert:  caPath,
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(opts) != 1 {
+			t.Errorf("expected 1 opt (grpc dial option), got %d", len(opts))
+		}
+	})
+
+	t.Run("tcp with TLS bad cert returns error", func(t *testing.T) {
+		_, err := buildClientOpts(context.Background(), "tcp://10.0.0.1:1234", config.BuildKitConfig{
+			TLSEnabled: true,
+			TLSCACert:  "/nonexistent/ca.pem",
+		})
+		if err == nil {
+			t.Fatal("expected error for bad TLS cert path")
+		}
+	})
 }
 
 func TestApplyPlatformFix_PropagatesError(t *testing.T) {


### PR DESCRIPTION
**Key Changes:**

- Enforced secure BuildKit TCP connections unless explicitly overridden by an environment variable
- Refactored shell command execution to use argument arrays instead of shell string parsing
- Improved handling of temporary tar files during image build to prevent file collisions and errors
- Enhanced logging for insecure connection overrides

**Changed:**

- BuildKit TCP connection security - Now requires either TLS or explicit opt-in for insecure plaintext TCP via the `BUILDKIT_INSECURE_NO_TLS` environment variable; otherwise, connection is blocked with an error message
- Shell and provisioner command execution - Replaced usage of `llb.Shlex` and `llb.Shlexf` with `llb.Args` to avoid shell interpretation issues and better handle command argument parsing for all provisioners (shell, file, script, PowerShell, Ansible)
- Temporary image tar file creation - Switched from using `filepath.Join(os.TempDir(), ...)` to `os.CreateTemp` for generating unique temporary tar files in both `Build` and `BuildDockerfile` methods, with error handling for file creation and closure
- Logging for insecure connection - Updated warning to clarify when the insecure override is in effect, making it explicit in logs when the override is used