### PR TITLE
fix: properly escape shell variables and extra-vars, improve temp file handling

### DIFF
--- a/builder/ami/component.go
+++ b/builder/ami/component.go
@@ -134,7 +134,7 @@ func (g *ComponentGenerator) createShellComponent(provisioner builder.Provisione
 	if len(provisioner.Environment) > 0 {
 		envVars := make([]string, 0, len(provisioner.Environment))
 		for key, value := range provisioner.Environment {
-			envVars = append(envVars, fmt.Sprintf("export %s=%s", key, value))
+			envVars = append(envVars, fmt.Sprintf("export %s='%s'", key, shellEscapeSingleQuote(value)))
 		}
 		doc["phases"].([]map[string]interface{})[0]["steps"].([]map[string]interface{})[0]["inputs"].(map[string]interface{})["commands"] = append(envVars, commands...)
 	}
@@ -228,12 +228,8 @@ func (g *ComponentGenerator) createLinuxAnsibleComponent(provisioner builder.Pro
 
 	ansibleCmd := fmt.Sprintf("ansible-playbook /tmp/%s", playbookName)
 
-	if len(provisioner.ExtraVars) > 0 {
-		var extraVars []string
-		for key, value := range provisioner.ExtraVars {
-			extraVars = append(extraVars, fmt.Sprintf("%s=%s", key, value))
-		}
-		ansibleCmd += fmt.Sprintf(" -e '%s'", strings.Join(extraVars, " "))
+	for key, value := range provisioner.ExtraVars {
+		ansibleCmd += fmt.Sprintf(" -e '%s=%s'", key, shellEscapeSingleQuote(value))
 	}
 
 	if provisioner.Inventory != "" {
@@ -323,19 +319,13 @@ func (g *ComponentGenerator) createWindowsAnsibleComponent(provisioner builder.P
 
 	ansibleCmd := fmt.Sprintf("ansible-playbook 'C:\\temp\\%s'", playbookName)
 
-	if len(provisioner.ExtraVars) > 0 {
-		var extraVars []string
-		for key, value := range provisioner.ExtraVars {
-			// Skip ansible connection vars for local execution
-			if key == "ansible_connection" || key == "ansible_shell_type" ||
-				key == "ansible_aws_ssm_bucket_name" || key == "ansible_aws_ssm_region" {
-				continue
-			}
-			extraVars = append(extraVars, fmt.Sprintf("%s=%s", key, value))
+	for key, value := range provisioner.ExtraVars {
+		// Skip ansible connection vars for local execution
+		if key == "ansible_connection" || key == "ansible_shell_type" ||
+			key == "ansible_aws_ssm_bucket_name" || key == "ansible_aws_ssm_region" {
+			continue
 		}
-		if len(extraVars) > 0 {
-			ansibleCmd += fmt.Sprintf(" -e '%s'", strings.Join(extraVars, " "))
-		}
+		ansibleCmd += fmt.Sprintf(" -e '%s=%s'", key, shellEscapeSingleQuote(value))
 	}
 
 	// Force local connection for Windows AMI builds
@@ -508,6 +498,13 @@ func needsReboot(script string) bool {
 		}
 	}
 	return false
+}
+
+// shellEscapeSingleQuote escapes a string for safe use inside a single-quoted shell argument.
+// A single quote cannot appear inside a single-quoted string in POSIX shell, so each
+// embedded single quote is replaced with the sequence: '\” (close-quote, literal-quote, re-open-quote).
+func shellEscapeSingleQuote(s string) string {
+	return strings.ReplaceAll(s, "'", "'\\''")
 }
 
 // marshalComponentDocument converts a component document to YAML string

--- a/builder/ami/component_test.go
+++ b/builder/ami/component_test.go
@@ -294,6 +294,24 @@ func TestCreateLinuxAnsibleComponent_WithExtraVarsAndInventory(t *testing.T) {
 	assert.NotContains(t, doc, "--connection=local")
 }
 
+func TestCreateLinuxAnsibleComponent_ExtraVarsEscaping(t *testing.T) {
+	t.Parallel()
+	tmpDir := t.TempDir()
+	playbookPath := filepath.Join(tmpDir, "playbook.yml")
+	require.NoError(t, os.WriteFile(playbookPath, []byte("---\n- hosts: all"), 0644))
+
+	gen := &ComponentGenerator{}
+	provisioner := builder.Provisioner{
+		Type:         "ansible",
+		PlaybookPath: playbookPath,
+		ExtraVars:    map[string]string{"msg": "it's"},
+	}
+
+	doc, err := gen.createLinuxAnsibleComponent(provisioner)
+	require.NoError(t, err)
+	assert.Contains(t, doc, "msg=it'\\''s")
+}
+
 func TestCreateLinuxAnsibleComponent_NonexistentPlaybook(t *testing.T) {
 	t.Parallel()
 	gen := &ComponentGenerator{}
@@ -417,6 +435,24 @@ func TestCreateWindowsAnsibleComponent_WithExtraVars(t *testing.T) {
 	assert.Contains(t, doc, "env=prod")
 }
 
+func TestCreateWindowsAnsibleComponent_ExtraVarsEscaping(t *testing.T) {
+	t.Parallel()
+	tmpDir := t.TempDir()
+	playbookPath := filepath.Join(tmpDir, "playbook.yml")
+	require.NoError(t, os.WriteFile(playbookPath, []byte("---\n- hosts: all"), 0644))
+
+	gen := &ComponentGenerator{}
+	provisioner := builder.Provisioner{
+		Type:         "ansible",
+		PlaybookPath: playbookPath,
+		ExtraVars:    map[string]string{"msg": "it's"},
+	}
+
+	doc, err := gen.createWindowsAnsibleComponent(provisioner)
+	require.NoError(t, err)
+	assert.Contains(t, doc, "msg=it'\\''s")
+}
+
 func TestCreateWindowsAnsibleComponent_NonexistentPlaybook(t *testing.T) {
 	t.Parallel()
 	gen := &ComponentGenerator{}
@@ -448,6 +484,48 @@ func TestCreateWindowsAnsibleComponent_NonexistentGalaxyFile(t *testing.T) {
 	assert.Contains(t, err.Error(), "failed to read galaxy file")
 }
 
+func TestShellEscapeSingleQuote(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "no quotes",
+			input:    "hello",
+			expected: "hello",
+		},
+		{
+			name:     "single quote in middle",
+			input:    "it's",
+			expected: "it'\\''s",
+		},
+		{
+			name:     "multiple single quotes",
+			input:    "it's a 'test'",
+			expected: "it'\\''s a '\\''test'\\''",
+		},
+		{
+			name:     "empty string",
+			input:    "",
+			expected: "",
+		},
+		{
+			name:     "only single quote",
+			input:    "'",
+			expected: "'\\''",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := shellEscapeSingleQuote(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
 func TestShellComponent_WithEnvironment(t *testing.T) {
 	t.Parallel()
 	gen := &ComponentGenerator{}
@@ -462,7 +540,28 @@ func TestShellComponent_WithEnvironment(t *testing.T) {
 
 	doc, err := gen.createShellComponent(provisioner)
 	require.NoError(t, err)
-	assert.Contains(t, doc, "export")
+	assert.Contains(t, doc, "export FOO='bar'")
+	assert.Contains(t, doc, "export BAZ='qux'")
+}
+
+func TestShellComponent_WithEnvironmentSpecialChars(t *testing.T) {
+	t.Parallel()
+	gen := &ComponentGenerator{}
+	provisioner := builder.Provisioner{
+		Type:   "shell",
+		Inline: []string{"echo hello"},
+		Environment: map[string]string{
+			"GREETING": "it's a test",
+			"CMD":      "$(whoami)",
+		},
+	}
+
+	doc, err := gen.createShellComponent(provisioner)
+	require.NoError(t, err)
+	// Single quotes should be escaped with the '\'' technique
+	assert.Contains(t, doc, "export GREETING='it'\\''s a test'")
+	// Command substitution should be safely quoted (single quotes prevent expansion)
+	assert.Contains(t, doc, "export CMD='$(whoami)'")
 }
 
 func TestGetComponentARN_Success(t *testing.T) {

--- a/builder/buildkit/buildkit.go
+++ b/builder/buildkit/buildkit.go
@@ -71,8 +71,9 @@ import (
 
 // Package-level function variables for daemon operations (overridden in tests).
 var (
-	daemonLoad  = daemon.Image
-	daemonWrite = daemon.Write
+	daemonLoad      = daemon.Image
+	daemonWrite     = daemon.Write
+	createTempImage = createTempImageTar
 )
 
 // BuildKitBuilder implements container image building using Docker BuildKit.
@@ -1224,7 +1225,7 @@ func (b *BuildKitBuilder) Build(ctx context.Context, cfg builder.Config) (*build
 		imageName = fmt.Sprintf("%s/%s", cfg.Registry, imageName)
 	}
 
-	imageTarPath, err := createTempImageTar()
+	imageTarPath, err := createTempImage()
 	if err != nil {
 		return nil, err
 	}
@@ -1862,7 +1863,7 @@ func (b *BuildKitBuilder) BuildDockerfile(ctx context.Context, cfg builder.Confi
 		frontendAttrs["no-cache"] = ""
 	}
 
-	imageTarPath, err := createTempImageTar()
+	imageTarPath, err := createTempImage()
 	if err != nil {
 		return nil, err
 	}

--- a/builder/buildkit/buildkit.go
+++ b/builder/buildkit/buildkit.go
@@ -1224,7 +1224,14 @@ func (b *BuildKitBuilder) Build(ctx context.Context, cfg builder.Config) (*build
 		imageName = fmt.Sprintf("%s/%s", cfg.Registry, imageName)
 	}
 
-	imageTarPath := filepath.Join(os.TempDir(), fmt.Sprintf("warpgate-image-%d.tar", time.Now().Unix()))
+	tmpFile, err := os.CreateTemp("", "warpgate-image-*.tar")
+	if err != nil {
+		return nil, fmt.Errorf("failed to create temporary image tar: %w", err)
+	}
+	imageTarPath := tmpFile.Name()
+	if err := tmpFile.Close(); err != nil {
+		return nil, fmt.Errorf("failed to close temporary image tar: %w", err)
+	}
 	defer func() {
 		if err := os.Remove(imageTarPath); err != nil {
 			logging.WarnContext(ctx, "Failed to remove temporary image tar: %v", err)
@@ -1844,7 +1851,14 @@ func (b *BuildKitBuilder) BuildDockerfile(ctx context.Context, cfg builder.Confi
 		frontendAttrs["no-cache"] = ""
 	}
 
-	imageTarPath := filepath.Join(os.TempDir(), fmt.Sprintf("warpgate-image-%d.tar", time.Now().Unix()))
+	tmpFile, err := os.CreateTemp("", "warpgate-image-*.tar")
+	if err != nil {
+		return nil, fmt.Errorf("failed to create temporary image tar: %w", err)
+	}
+	imageTarPath := tmpFile.Name()
+	if err := tmpFile.Close(); err != nil {
+		return nil, fmt.Errorf("failed to close temporary image tar: %w", err)
+	}
 	defer func() {
 		if err := os.Remove(imageTarPath); err != nil {
 			logging.WarnContext(ctx, "Failed to remove temporary image tar: %v", err)

--- a/builder/buildkit/buildkit.go
+++ b/builder/buildkit/buildkit.go
@@ -1224,13 +1224,9 @@ func (b *BuildKitBuilder) Build(ctx context.Context, cfg builder.Config) (*build
 		imageName = fmt.Sprintf("%s/%s", cfg.Registry, imageName)
 	}
 
-	tmpFile, err := os.CreateTemp("", "warpgate-image-*.tar")
+	imageTarPath, err := createTempImageTar()
 	if err != nil {
-		return nil, fmt.Errorf("failed to create temporary image tar: %w", err)
-	}
-	imageTarPath := tmpFile.Name()
-	if err := tmpFile.Close(); err != nil {
-		return nil, fmt.Errorf("failed to close temporary image tar: %w", err)
+		return nil, err
 	}
 	defer func() {
 		if err := os.Remove(imageTarPath); err != nil {
@@ -1302,6 +1298,21 @@ func (b *BuildKitBuilder) Build(ctx context.Context, cfg builder.Config) (*build
 //
 // Resource Management: The created file handle must be closed by the caller.
 // BuildKit typically handles this automatically when the solve operation completes.
+
+// createTempImageTar creates a temporary file for storing a Docker image tar.
+// The caller is responsible for removing the file when done.
+func createTempImageTar() (string, error) {
+	tmpFile, err := os.CreateTemp("", "warpgate-image-*.tar")
+	if err != nil {
+		return "", fmt.Errorf("failed to create temporary image tar: %w", err)
+	}
+	path := tmpFile.Name()
+	if err := tmpFile.Close(); err != nil {
+		return "", fmt.Errorf("failed to close temporary image tar: %w", err)
+	}
+	return path, nil
+}
+
 func fixedWriteCloser(filepath string) func(map[string]string) (io.WriteCloser, error) {
 	return func(m map[string]string) (io.WriteCloser, error) {
 		f, err := os.Create(filepath)
@@ -1851,13 +1862,9 @@ func (b *BuildKitBuilder) BuildDockerfile(ctx context.Context, cfg builder.Confi
 		frontendAttrs["no-cache"] = ""
 	}
 
-	tmpFile, err := os.CreateTemp("", "warpgate-image-*.tar")
+	imageTarPath, err := createTempImageTar()
 	if err != nil {
-		return nil, fmt.Errorf("failed to create temporary image tar: %w", err)
-	}
-	imageTarPath := tmpFile.Name()
-	if err := tmpFile.Close(); err != nil {
-		return nil, fmt.Errorf("failed to close temporary image tar: %w", err)
+		return nil, err
 	}
 	defer func() {
 		if err := os.Remove(imageTarPath); err != nil {

--- a/builder/buildkit/buildkit_test.go
+++ b/builder/buildkit/buildkit_test.go
@@ -7830,6 +7830,50 @@ func TestBuildClientOpts(t *testing.T) {
 	})
 }
 
+func TestCreateTempImageTar(t *testing.T) {
+	t.Run("creates and closes temp file successfully", func(t *testing.T) {
+		path, err := createTempImageTar()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		defer os.Remove(path)
+
+		if !strings.Contains(path, "warpgate-image-") {
+			t.Errorf("expected path to contain 'warpgate-image-', got %s", path)
+		}
+		if !strings.HasSuffix(path, ".tar") {
+			t.Errorf("expected path to end with '.tar', got %s", path)
+		}
+
+		// File should exist but be closed (writable by another open)
+		info, err := os.Stat(path)
+		if err != nil {
+			t.Fatalf("temp file should exist: %v", err)
+		}
+		if info.Size() != 0 {
+			t.Errorf("expected empty file, got %d bytes", info.Size())
+		}
+	})
+
+	t.Run("returned path is unique across calls", func(t *testing.T) {
+		path1, err := createTempImageTar()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		defer os.Remove(path1)
+
+		path2, err := createTempImageTar()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		defer os.Remove(path2)
+
+		if path1 == path2 {
+			t.Error("expected unique paths, got identical")
+		}
+	})
+}
+
 func TestApplyPlatformFix_PropagatesError(t *testing.T) {
 	origLoad := daemonLoad
 	defer func() { daemonLoad = origLoad }()

--- a/builder/buildkit/buildkit_test.go
+++ b/builder/buildkit/buildkit_test.go
@@ -7836,7 +7836,11 @@ func TestCreateTempImageTar(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		defer os.Remove(path)
+		defer func() {
+			if err := os.Remove(path); err != nil {
+				t.Logf("cleanup: %v", err)
+			}
+		}()
 
 		if !strings.Contains(path, "warpgate-image-") {
 			t.Errorf("expected path to contain 'warpgate-image-', got %s", path)
@@ -7860,18 +7864,71 @@ func TestCreateTempImageTar(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		defer os.Remove(path1)
+		defer func() {
+			if err := os.Remove(path1); err != nil {
+				t.Logf("cleanup: %v", err)
+			}
+		}()
 
 		path2, err := createTempImageTar()
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		defer os.Remove(path2)
+		defer func() {
+			if err := os.Remove(path2); err != nil {
+				t.Logf("cleanup: %v", err)
+			}
+		}()
 
 		if path1 == path2 {
 			t.Error("expected unique paths, got identical")
 		}
 	})
+
+	t.Run("returns error when temp dir is not writable", func(t *testing.T) {
+		t.Setenv("TMPDIR", "/nonexistent-dir-that-does-not-exist")
+
+		_, err := createTempImageTar()
+		if err == nil {
+			t.Fatal("expected error when TMPDIR is invalid")
+		}
+		if !strings.Contains(err.Error(), "failed to create temporary image tar") {
+			t.Errorf("unexpected error message: %v", err)
+		}
+	})
+}
+
+func TestBuildDockerfile_TempFileError(t *testing.T) {
+	orig := createTempImage
+	defer func() { createTempImage = orig }()
+
+	createTempImage = func() (string, error) {
+		return "", fmt.Errorf("injected temp file error")
+	}
+
+	tmpDir := t.TempDir()
+	dockerfilePath := filepath.Join(tmpDir, "Dockerfile")
+	if err := os.WriteFile(dockerfilePath, []byte("FROM scratch\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	b := &BuildKitBuilder{}
+	cfg := builder.Config{
+		Name:    "test",
+		Version: "1.0",
+		Dockerfile: &builder.DockerfileConfig{
+			Path:    dockerfilePath,
+			Context: tmpDir,
+		},
+	}
+
+	_, err := b.BuildDockerfile(context.Background(), cfg)
+	if err == nil {
+		t.Fatal("expected error from injected createTempImage failure")
+	}
+	if !strings.Contains(err.Error(), "injected temp file error") {
+		t.Errorf("unexpected error: %v", err)
+	}
 }
 
 func TestApplyPlatformFix_PropagatesError(t *testing.T) {

--- a/builder/buildkit/buildkit_test.go
+++ b/builder/buildkit/buildkit_test.go
@@ -7931,6 +7931,33 @@ func TestBuildDockerfile_TempFileError(t *testing.T) {
 	}
 }
 
+func TestBuild_TempFileError(t *testing.T) {
+	orig := createTempImage
+	defer func() { createTempImage = orig }()
+
+	createTempImage = func() (string, error) {
+		return "", fmt.Errorf("injected temp file error")
+	}
+
+	b := &BuildKitBuilder{}
+	cfg := builder.Config{
+		Name:    "test",
+		Version: "1.0",
+		Base: builder.BaseImage{
+			Image:    "alpine:latest",
+			Platform: "linux/amd64",
+		},
+	}
+
+	_, err := b.Build(context.Background(), cfg)
+	if err == nil {
+		t.Fatal("expected error from injected createTempImage failure")
+	}
+	if !strings.Contains(err.Error(), "injected temp file error") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
 func TestApplyPlatformFix_PropagatesError(t *testing.T) {
 	origLoad := daemonLoad
 	defer func() { daemonLoad = origLoad }()


### PR DESCRIPTION
**Key Changes:**

- Fixed shell and ansible variable escaping to safely handle single quotes and special characters
- Improved creation and cleanup of temporary image tar files to prevent file collisions and resource leaks
- Added comprehensive tests for shell escaping logic and environment/extra-vars handling

**Added:**

- shellEscapeSingleQuote function to safely escape single quotes for shell and ansible variables
- Unit tests covering shellEscapeSingleQuote, Linux and Windows Ansible component escaping, and shell environment variable quoting

**Changed:**

- Updated shell and ansible command generation to use shellEscapeSingleQuote for all variable values, ensuring safe command construction
- Switched from using time-based filenames to os.CreateTemp for temporary image tar files in BuildKitBuilder, ensuring unique and securely created files
- Enhanced test coverage for environment variable handling with special characters and command substitutions

**Removed:**

- Legacy logic for manual extra-vars string assembly, replaced by iterative escaping and command building