### PR TITLE
feat: add support for S3-staged file provisioners in AMI builds

### DIFF
--- a/builder/ami/aws_interfaces.go
+++ b/builder/ami/aws_interfaces.go
@@ -29,8 +29,18 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	"github.com/aws/aws-sdk-go-v2/service/iam"
 	"github.com/aws/aws-sdk-go-v2/service/imagebuilder"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/aws-sdk-go-v2/service/ssm"
 )
+
+// S3API matches the subset of S3 operations used to stage `file` provisioner
+// sources. Compatible with bcp's transfer.S3API so its helpers can consume it.
+type S3API interface {
+	PutObject(ctx context.Context, params *s3.PutObjectInput, optFns ...func(*s3.Options)) (*s3.PutObjectOutput, error)
+	GetObject(ctx context.Context, params *s3.GetObjectInput, optFns ...func(*s3.Options)) (*s3.GetObjectOutput, error)
+	DeleteObject(ctx context.Context, params *s3.DeleteObjectInput, optFns ...func(*s3.Options)) (*s3.DeleteObjectOutput, error)
+	ListObjectsV2(ctx context.Context, params *s3.ListObjectsV2Input, optFns ...func(*s3.Options)) (*s3.ListObjectsV2Output, error)
+}
 
 // EC2API defines the EC2 operations used in this package.
 type EC2API interface {

--- a/builder/ami/aws_interfaces_test.go
+++ b/builder/ami/aws_interfaces_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	"github.com/aws/aws-sdk-go-v2/service/iam"
 	"github.com/aws/aws-sdk-go-v2/service/imagebuilder"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/aws-sdk-go-v2/service/ssm"
 )
 
@@ -40,7 +41,44 @@ var (
 	_ IAMAPI            = (*MockIAMClient)(nil)
 	_ SSMAPI            = (*MockSSMClient)(nil)
 	_ CloudWatchLogsAPI = (*MockCloudWatchLogsClient)(nil)
+	_ S3API             = (*MockS3Client)(nil)
 )
+
+// MockS3Client implements S3API for testing.
+type MockS3Client struct {
+	PutObjectFunc     func(ctx context.Context, params *s3.PutObjectInput, optFns ...func(*s3.Options)) (*s3.PutObjectOutput, error)
+	GetObjectFunc     func(ctx context.Context, params *s3.GetObjectInput, optFns ...func(*s3.Options)) (*s3.GetObjectOutput, error)
+	DeleteObjectFunc  func(ctx context.Context, params *s3.DeleteObjectInput, optFns ...func(*s3.Options)) (*s3.DeleteObjectOutput, error)
+	ListObjectsV2Func func(ctx context.Context, params *s3.ListObjectsV2Input, optFns ...func(*s3.Options)) (*s3.ListObjectsV2Output, error)
+}
+
+func (m *MockS3Client) PutObject(ctx context.Context, params *s3.PutObjectInput, optFns ...func(*s3.Options)) (*s3.PutObjectOutput, error) {
+	if m.PutObjectFunc != nil {
+		return m.PutObjectFunc(ctx, params, optFns...)
+	}
+	return &s3.PutObjectOutput{}, nil
+}
+
+func (m *MockS3Client) GetObject(ctx context.Context, params *s3.GetObjectInput, optFns ...func(*s3.Options)) (*s3.GetObjectOutput, error) {
+	if m.GetObjectFunc != nil {
+		return m.GetObjectFunc(ctx, params, optFns...)
+	}
+	return &s3.GetObjectOutput{}, nil
+}
+
+func (m *MockS3Client) DeleteObject(ctx context.Context, params *s3.DeleteObjectInput, optFns ...func(*s3.Options)) (*s3.DeleteObjectOutput, error) {
+	if m.DeleteObjectFunc != nil {
+		return m.DeleteObjectFunc(ctx, params, optFns...)
+	}
+	return &s3.DeleteObjectOutput{}, nil
+}
+
+func (m *MockS3Client) ListObjectsV2(ctx context.Context, params *s3.ListObjectsV2Input, optFns ...func(*s3.Options)) (*s3.ListObjectsV2Output, error) {
+	if m.ListObjectsV2Func != nil {
+		return m.ListObjectsV2Func(ctx, params, optFns...)
+	}
+	return &s3.ListObjectsV2Output{}, nil
+}
 
 // MockEC2Client implements EC2API for testing.
 type MockEC2Client struct {
@@ -413,6 +451,7 @@ type mockClients struct {
 	iam            *MockIAMClient
 	ssm            *MockSSMClient
 	cloudWatchLogs *MockCloudWatchLogsClient
+	s3             *MockS3Client
 }
 
 // newMockAWSClients creates an AWSClients with all mock implementations and returns
@@ -424,6 +463,7 @@ func newMockAWSClients() (*AWSClients, *mockClients) {
 		iam:            &MockIAMClient{},
 		ssm:            &MockSSMClient{},
 		cloudWatchLogs: &MockCloudWatchLogsClient{},
+		s3:             &MockS3Client{},
 	}
 
 	clients := &AWSClients{
@@ -432,6 +472,7 @@ func newMockAWSClients() (*AWSClients, *mockClients) {
 		IAM:            mocks.iam,
 		SSM:            mocks.ssm,
 		CloudWatchLogs: mocks.cloudWatchLogs,
+		S3:             mocks.s3,
 		Config:         aws.Config{Region: "us-east-1"},
 	}
 

--- a/builder/ami/client.go
+++ b/builder/ami/client.go
@@ -33,6 +33,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	"github.com/aws/aws-sdk-go-v2/service/iam"
 	"github.com/aws/aws-sdk-go-v2/service/imagebuilder"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/aws-sdk-go-v2/service/ssm"
 )
 
@@ -45,6 +46,7 @@ type AWSClients struct {
 	IAM            IAMAPI
 	SSM            SSMAPI
 	CloudWatchLogs CloudWatchLogsAPI
+	S3             S3API
 	Config         aws.Config
 }
 
@@ -103,6 +105,7 @@ func NewAWSClients(ctx context.Context, cfg ClientConfig) (*AWSClients, error) {
 		IAM:            iam.NewFromConfig(awsCfg),
 		SSM:            ssm.NewFromConfig(awsCfg),
 		CloudWatchLogs: cloudwatchlogs.NewFromConfig(awsCfg),
+		S3:             s3.NewFromConfig(awsCfg),
 		Config:         awsCfg,
 	}
 

--- a/builder/ami/component.go
+++ b/builder/ami/component.go
@@ -49,9 +49,18 @@ func NewComponentGenerator(clients *AWSClients) *ComponentGenerator {
 	}
 }
 
+// GenerateComponentOpts carries optional context required to generate a
+// component document. Currently used to pass S3 staging info for the `file`
+// provisioner; safe to leave zero-valued for other provisioner types.
+type GenerateComponentOpts struct {
+	// StagedFile is the result of pre-uploading a `file` provisioner's source
+	// to S3. Only consulted when provisioner.Type == "file".
+	StagedFile *StagedFile
+}
+
 // GenerateComponent creates an Image Builder component from a provisioner
-func (g *ComponentGenerator) GenerateComponent(ctx context.Context, provisioner builder.Provisioner, name, version string) (*string, error) {
-	document, err := g.createComponentDocument(provisioner)
+func (g *ComponentGenerator) GenerateComponent(ctx context.Context, provisioner builder.Provisioner, name, version string, opts GenerateComponentOpts) (*string, error) {
+	document, err := g.createComponentDocument(provisioner, opts)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create component document: %w", err)
 	}
@@ -88,7 +97,7 @@ func (g *ComponentGenerator) GenerateComponent(ctx context.Context, provisioner 
 }
 
 // createComponentDocument generates a YAML document for the Image Builder component
-func (g *ComponentGenerator) createComponentDocument(provisioner builder.Provisioner) (string, error) {
+func (g *ComponentGenerator) createComponentDocument(provisioner builder.Provisioner, opts GenerateComponentOpts) (string, error) {
 	switch provisioner.Type {
 	case "shell":
 		return g.createShellComponent(provisioner)
@@ -98,9 +107,68 @@ func (g *ComponentGenerator) createComponentDocument(provisioner builder.Provisi
 		return g.createAnsibleComponent(provisioner)
 	case "powershell":
 		return g.createPowerShellComponent(provisioner)
+	case "file":
+		return g.createFileComponent(provisioner, opts.StagedFile)
 	default:
 		return "", fmt.Errorf("unsupported provisioner type: %s", provisioner.Type)
 	}
+}
+
+// createFileComponent emits an S3Download component referencing the staged
+// upload. The build instance's IAM profile must allow s3:GetObject on the
+// staging bucket. If a Mode is set on the provisioner, a follow-on
+// ExecuteBash step applies it via chmod (Linux only — Windows file
+// provisioner mode is not supported).
+func (g *ComponentGenerator) createFileComponent(provisioner builder.Provisioner, staged *StagedFile) (string, error) {
+	if provisioner.Source == "" {
+		return "", fmt.Errorf("file provisioner has no source")
+	}
+	if provisioner.Destination == "" {
+		return "", fmt.Errorf("file provisioner has no destination")
+	}
+	if staged == nil {
+		return "", fmt.Errorf("file provisioner source has not been staged to S3 — set aws.ami.file_staging_bucket")
+	}
+
+	steps := []map[string]interface{}{
+		{
+			"name":   "DownloadFile",
+			"action": "S3Download",
+			"inputs": []map[string]interface{}{
+				{
+					"source":      staged.SourceURI(),
+					"destination": provisioner.Destination,
+					"overwrite":   true,
+				},
+			},
+		},
+	}
+
+	if provisioner.Mode != "" && determinePlatform(provisioner) != types.PlatformWindows {
+		steps = append(steps, map[string]interface{}{
+			"name":   "ApplyMode",
+			"action": "ExecuteBash",
+			"inputs": map[string]interface{}{
+				"commands": []string{
+					fmt.Sprintf("chmod -R %s %s", provisioner.Mode, provisioner.Destination),
+				},
+			},
+		})
+	}
+
+	doc := map[string]interface{}{
+		"schemaVersion": 1.0,
+		"name":          "FileProvisioner",
+		"description":   "File provisioner component (S3Download)",
+		"phases": []map[string]interface{}{
+			{
+				"name":  "build",
+				"steps": steps,
+			},
+		},
+	}
+
+	return marshalComponentDocument(doc)
 }
 
 // createShellComponent creates a component document for shell provisioner

--- a/builder/ami/component_test.go
+++ b/builder/ami/component_test.go
@@ -63,7 +63,7 @@ func TestGenerateComponent_Success(t *testing.T) {
 		Inline: []string{"echo hello"},
 	}
 
-	arn, err := gen.GenerateComponent(context.Background(), provisioner, "test", "1.0.0")
+	arn, err := gen.GenerateComponent(context.Background(), provisioner, "test", "1.0.0", GenerateComponentOpts{})
 	require.NoError(t, err)
 	assert.Equal(t, expectedARN, *arn)
 }
@@ -93,7 +93,7 @@ func TestGenerateComponent_AlreadyExists(t *testing.T) {
 		Inline: []string{"echo hello"},
 	}
 
-	arn, err := gen.GenerateComponent(context.Background(), provisioner, "test", "1.0.0")
+	arn, err := gen.GenerateComponent(context.Background(), provisioner, "test", "1.0.0", GenerateComponentOpts{})
 	require.NoError(t, err)
 	assert.Equal(t, expectedARN, *arn)
 }
@@ -115,7 +115,7 @@ func TestGenerateComponent_AlreadyExistsButGetARNFails(t *testing.T) {
 		Inline: []string{"echo hello"},
 	}
 
-	_, err := gen.GenerateComponent(context.Background(), provisioner, "test", "1.0.0")
+	_, err := gen.GenerateComponent(context.Background(), provisioner, "test", "1.0.0", GenerateComponentOpts{})
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "component exists but failed to get ARN")
 }
@@ -134,7 +134,7 @@ func TestGenerateComponent_CreateError(t *testing.T) {
 		Inline: []string{"echo hello"},
 	}
 
-	_, err := gen.GenerateComponent(context.Background(), provisioner, "test", "1.0.0")
+	_, err := gen.GenerateComponent(context.Background(), provisioner, "test", "1.0.0", GenerateComponentOpts{})
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to create component")
 }
@@ -148,7 +148,7 @@ func TestGenerateComponent_InvalidDocument(t *testing.T) {
 		Type: "unknown_type",
 	}
 
-	_, err := gen.GenerateComponent(context.Background(), provisioner, "test", "1.0.0")
+	_, err := gen.GenerateComponent(context.Background(), provisioner, "test", "1.0.0", GenerateComponentOpts{})
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to create component document")
 }
@@ -911,7 +911,7 @@ func TestCreateComponentDocument_AllTypes(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			gen := &ComponentGenerator{}
-			doc, err := gen.createComponentDocument(tt.provisioner)
+			doc, err := gen.createComponentDocument(tt.provisioner, GenerateComponentOpts{})
 			if tt.wantErr {
 				assert.Error(t, err)
 			} else {
@@ -1013,7 +1013,84 @@ func TestCreateScriptComponent_ViaComponentDocument(t *testing.T) {
 	doc, err := gen.createComponentDocument(builder.Provisioner{
 		Type:    "script",
 		Scripts: []string{scriptPath},
-	})
+	}, GenerateComponentOpts{})
 	require.NoError(t, err)
 	assert.True(t, strings.Contains(doc, "ScriptProvisioner"))
+}
+
+func TestCreateFileComponent_File(t *testing.T) {
+	t.Parallel()
+
+	gen := &ComponentGenerator{}
+	staged := &StagedFile{
+		Bucket:    "my-bucket",
+		KeyPrefix: "warpgate-staging/build-1/0/",
+		BaseName:  "app.tar.gz",
+	}
+	prov := builder.Provisioner{
+		Type:        "file",
+		Source:      "/local/app.tar.gz",
+		Destination: "/opt/app.tar.gz",
+		Mode:        "0644",
+	}
+
+	doc, err := gen.createComponentDocument(prov, GenerateComponentOpts{StagedFile: staged})
+	require.NoError(t, err)
+	assert.Contains(t, doc, "FileProvisioner")
+	assert.Contains(t, doc, "S3Download")
+	assert.Contains(t, doc, "s3://my-bucket/warpgate-staging/build-1/0/app.tar.gz")
+	assert.Contains(t, doc, "/opt/app.tar.gz")
+	assert.Contains(t, doc, "chmod -R 0644 /opt/app.tar.gz")
+}
+
+func TestCreateFileComponent_Directory(t *testing.T) {
+	t.Parallel()
+
+	gen := &ComponentGenerator{}
+	staged := &StagedFile{
+		Bucket:      "my-bucket",
+		KeyPrefix:   "warpgate-staging/build-2/1/",
+		IsDirectory: true,
+		BaseName:    "configs",
+	}
+	prov := builder.Provisioner{
+		Type:        "file",
+		Source:      "/local/configs",
+		Destination: "/etc/configs/",
+	}
+
+	doc, err := gen.createComponentDocument(prov, GenerateComponentOpts{StagedFile: staged})
+	require.NoError(t, err)
+	assert.Contains(t, doc, "s3://my-bucket/warpgate-staging/build-2/1/configs/*")
+	assert.NotContains(t, doc, "chmod")
+}
+
+func TestCreateFileComponent_MissingStaging(t *testing.T) {
+	t.Parallel()
+
+	gen := &ComponentGenerator{}
+	prov := builder.Provisioner{
+		Type:        "file",
+		Source:      "/local/file",
+		Destination: "/dest",
+	}
+
+	_, err := gen.createComponentDocument(prov, GenerateComponentOpts{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "file_staging_bucket")
+}
+
+func TestCreateFileComponent_MissingFields(t *testing.T) {
+	t.Parallel()
+
+	gen := &ComponentGenerator{}
+	staged := &StagedFile{Bucket: "b", BaseName: "f"}
+
+	_, err := gen.createComponentDocument(builder.Provisioner{Type: "file", Destination: "/d"}, GenerateComponentOpts{StagedFile: staged})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no source")
+
+	_, err = gen.createComponentDocument(builder.Provisioner{Type: "file", Source: "/s"}, GenerateComponentOpts{StagedFile: staged})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no destination")
 }

--- a/builder/ami/file_stager.go
+++ b/builder/ami/file_stager.go
@@ -1,0 +1,111 @@
+/*
+Copyright © 2026 Jayson Grace <jayson.e.grace@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+package ami
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	bcptransfer "github.com/cowdogmoo/bcp/pkg/transfer"
+	"github.com/cowdogmoo/warpgate/v3/logging"
+)
+
+// StagedFile records an upload performed by FileStager so it can be cleaned
+// up after the build, and so the AMI component can reference the S3 source.
+type StagedFile struct {
+	Bucket      string
+	KeyPrefix   string
+	IsDirectory bool
+	BaseName    string
+}
+
+// SourceURI returns the s3:// URI suitable for an Image Builder S3Download
+// step. For directories it appends a wildcard so all objects under the
+// prefix are pulled.
+func (s *StagedFile) SourceURI() string {
+	if s.IsDirectory {
+		return fmt.Sprintf("s3://%s/%s%s/*", s.Bucket, s.KeyPrefix, s.BaseName)
+	}
+	return fmt.Sprintf("s3://%s/%s%s", s.Bucket, s.KeyPrefix, s.BaseName)
+}
+
+// FileStager uploads `file` provisioner sources to an S3 bucket so the AMI
+// build instance can fetch them via S3Download. It delegates the upload and
+// cleanup primitives to bcp.
+type FileStager struct {
+	Client S3API
+	Bucket string
+}
+
+// NewFileStager constructs a stager. Returns nil if bucket is empty so callers
+// can detect the disabled state.
+func NewFileStager(client S3API, bucket string) *FileStager {
+	if bucket == "" {
+		return nil
+	}
+	return &FileStager{Client: client, Bucket: bucket}
+}
+
+// Stage uploads source to S3 under keyPrefix. Caller is responsible for
+// keying prefixes uniquely (e.g., per build + provisioner index) so concurrent
+// or repeated builds don't collide.
+func (s *FileStager) Stage(ctx context.Context, source, keyPrefix string) (*StagedFile, error) {
+	info, err := os.Stat(source)
+	if err != nil {
+		return nil, fmt.Errorf("stat file provisioner source %q: %w", source, err)
+	}
+
+	logging.InfoContext(ctx, "Staging %q to s3://%s/%s", source, s.Bucket, keyPrefix)
+
+	if err := bcptransfer.UploadToS3WithPrefix(ctx, s.Client, s.Bucket, source, keyPrefix); err != nil {
+		return nil, fmt.Errorf("upload %q to s3://%s/%s: %w", source, s.Bucket, keyPrefix, err)
+	}
+
+	prefix := keyPrefix
+	if prefix != "" && prefix[len(prefix)-1] != '/' {
+		prefix += "/"
+	}
+
+	return &StagedFile{
+		Bucket:      s.Bucket,
+		KeyPrefix:   prefix,
+		IsDirectory: info.IsDir(),
+		BaseName:    filepath.Base(source),
+	}, nil
+}
+
+// Cleanup removes the staged objects from S3. Errors are logged but not
+// returned fatally — leaving stray objects shouldn't block reporting build
+// outcomes.
+func (s *FileStager) Cleanup(ctx context.Context, staged *StagedFile) {
+	if staged == nil {
+		return
+	}
+	key := staged.KeyPrefix + staged.BaseName
+	err := bcptransfer.CleanupS3Objects(ctx, s.Client, staged.Bucket, key, staged.IsDirectory)
+	if err != nil {
+		logging.WarnContext(ctx, "Failed to clean up staged S3 objects at s3://%s/%s: %v", staged.Bucket, key, err)
+	}
+}

--- a/builder/ami/file_stager_test.go
+++ b/builder/ami/file_stager_test.go
@@ -1,0 +1,206 @@
+/*
+Copyright © 2026 Jayson Grace <jayson.e.grace@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+package ami
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStagedFile_SourceURI(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		staged StagedFile
+		want   string
+	}{
+		{
+			name:   "single file",
+			staged: StagedFile{Bucket: "b", KeyPrefix: "p/", BaseName: "f.tar"},
+			want:   "s3://b/p/f.tar",
+		},
+		{
+			name:   "directory uses wildcard",
+			staged: StagedFile{Bucket: "b", KeyPrefix: "p/", IsDirectory: true, BaseName: "configs"},
+			want:   "s3://b/p/configs/*",
+		},
+		{
+			name:   "empty prefix",
+			staged: StagedFile{Bucket: "b", BaseName: "f"},
+			want:   "s3://b/f",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, tt.staged.SourceURI())
+		})
+	}
+}
+
+func TestNewFileStager(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns nil when bucket empty", func(t *testing.T) {
+		t.Parallel()
+		assert.Nil(t, NewFileStager(&MockS3Client{}, ""))
+	})
+
+	t.Run("returns stager when bucket set", func(t *testing.T) {
+		t.Parallel()
+		client := &MockS3Client{}
+		s := NewFileStager(client, "my-bucket")
+		require.NotNil(t, s)
+		assert.Equal(t, "my-bucket", s.Bucket)
+		assert.Equal(t, S3API(client), s.Client)
+	})
+}
+
+func TestFileStager_Stage_File(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	src := filepath.Join(dir, "payload.txt")
+	require.NoError(t, os.WriteFile(src, []byte("hello"), 0o600))
+
+	var mu sync.Mutex
+	var puts []string
+	mock := &MockS3Client{
+		PutObjectFunc: func(_ context.Context, params *s3.PutObjectInput, _ ...func(*s3.Options)) (*s3.PutObjectOutput, error) {
+			mu.Lock()
+			defer mu.Unlock()
+			puts = append(puts, *params.Key)
+			return &s3.PutObjectOutput{}, nil
+		},
+	}
+
+	stager := NewFileStager(mock, "bkt")
+	require.NotNil(t, stager)
+
+	staged, err := stager.Stage(context.Background(), src, "warpgate-staging/build/0")
+	require.NoError(t, err)
+	assert.Equal(t, "bkt", staged.Bucket)
+	assert.Equal(t, "warpgate-staging/build/0/", staged.KeyPrefix)
+	assert.False(t, staged.IsDirectory)
+	assert.Equal(t, "payload.txt", staged.BaseName)
+	assert.Equal(t, "s3://bkt/warpgate-staging/build/0/payload.txt", staged.SourceURI())
+	assert.Equal(t, []string{"warpgate-staging/build/0/payload.txt"}, puts)
+}
+
+func TestFileStager_Stage_Directory(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	srcDir := filepath.Join(dir, "configs")
+	require.NoError(t, os.MkdirAll(filepath.Join(srcDir, "nested"), 0o700))
+	require.NoError(t, os.WriteFile(filepath.Join(srcDir, "a.cfg"), []byte("a"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(srcDir, "nested", "b.cfg"), []byte("b"), 0o600))
+
+	mock := &MockS3Client{}
+	stager := NewFileStager(mock, "bkt")
+	staged, err := stager.Stage(context.Background(), srcDir, "warpgate-staging/build/1/")
+	require.NoError(t, err)
+	assert.True(t, staged.IsDirectory)
+	assert.Equal(t, "configs", staged.BaseName)
+	assert.Equal(t, "s3://bkt/warpgate-staging/build/1/configs/*", staged.SourceURI())
+}
+
+func TestFileStager_Stage_StatError(t *testing.T) {
+	t.Parallel()
+
+	stager := NewFileStager(&MockS3Client{}, "bkt")
+	_, err := stager.Stage(context.Background(), "/nonexistent/path/that/does-not/exist", "p")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "stat file provisioner source")
+}
+
+func TestFileStager_Stage_UploadError(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	src := filepath.Join(dir, "f.txt")
+	require.NoError(t, os.WriteFile(src, []byte("x"), 0o600))
+
+	mock := &MockS3Client{
+		PutObjectFunc: func(_ context.Context, _ *s3.PutObjectInput, _ ...func(*s3.Options)) (*s3.PutObjectOutput, error) {
+			return nil, errors.New("boom")
+		},
+	}
+	stager := NewFileStager(mock, "bkt")
+	_, err := stager.Stage(context.Background(), src, "p")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "upload")
+}
+
+func TestFileStager_Cleanup(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil staged is a no-op", func(t *testing.T) {
+		t.Parallel()
+		stager := NewFileStager(&MockS3Client{}, "bkt")
+		stager.Cleanup(context.Background(), nil)
+	})
+
+	t.Run("deletes single file", func(t *testing.T) {
+		t.Parallel()
+		var deletedKey string
+		mock := &MockS3Client{
+			DeleteObjectFunc: func(_ context.Context, params *s3.DeleteObjectInput, _ ...func(*s3.Options)) (*s3.DeleteObjectOutput, error) {
+				deletedKey = *params.Key
+				return &s3.DeleteObjectOutput{}, nil
+			},
+		}
+		stager := NewFileStager(mock, "bkt")
+		stager.Cleanup(context.Background(), &StagedFile{
+			Bucket:    "bkt",
+			KeyPrefix: "p/",
+			BaseName:  "f.txt",
+		})
+		assert.Equal(t, "p/f.txt", deletedKey)
+	})
+
+	t.Run("logs but does not panic on cleanup error", func(t *testing.T) {
+		t.Parallel()
+		mock := &MockS3Client{
+			DeleteObjectFunc: func(_ context.Context, _ *s3.DeleteObjectInput, _ ...func(*s3.Options)) (*s3.DeleteObjectOutput, error) {
+				return nil, errors.New("delete failed")
+			},
+		}
+		stager := NewFileStager(mock, "bkt")
+		stager.Cleanup(context.Background(), &StagedFile{
+			Bucket:    "bkt",
+			KeyPrefix: "p/",
+			BaseName:  "f.txt",
+		})
+	})
+}

--- a/builder/ami/imagebuilder.go
+++ b/builder/ami/imagebuilder.go
@@ -50,6 +50,7 @@ type ImageBuilder struct {
 	pipelineManager *PipelineManager
 	operations      *AMIOperations
 	resourceManager *ResourceManager
+	fileStager      *FileStager // nil when no staging bucket is configured
 	config          ClientConfig
 	globalConfig    *config.Config
 	forceRecreate   bool
@@ -87,12 +88,18 @@ func NewImageBuilderWithAllOptions(ctx context.Context, clientConfig ClientConfi
 	buildID := generateBuildID()
 	pipelineManager := NewPipelineManagerWithMonitor(clients, monitorConfig)
 
+	var fileStager *FileStager
+	if globalCfg != nil {
+		fileStager = NewFileStager(clients.S3, globalCfg.AWS.AMI.FileStagingBucket)
+	}
+
 	return &ImageBuilder{
 		clients:         clients,
 		componentGen:    NewComponentGenerator(clients),
 		pipelineManager: pipelineManager,
 		operations:      NewAMIOperations(clients, globalCfg),
 		resourceManager: NewResourceManager(clients),
+		fileStager:      fileStager,
 		config:          clientConfig,
 		globalConfig:    globalCfg,
 		forceRecreate:   forceRecreate,
@@ -159,7 +166,13 @@ func (b *ImageBuilder) Build(ctx context.Context, config builder.Config) (*build
 	// display is likely active and log output would corrupt the terminal.
 	quietCleanup := b.monitorConfig.StatusCallback != nil
 
-	resources, err := b.createBuildResources(ctx, config, amiTarget, createdResources)
+	stagedFiles, err := b.stageFileProvisioners(ctx, config)
+	if err != nil {
+		return nil, err
+	}
+	defer b.cleanupStagedFiles(ctx, stagedFiles)
+
+	resources, err := b.createBuildResources(ctx, config, amiTarget, createdResources, stagedFiles)
 	if err != nil {
 		createdResources.Cleanup(ctx, b.resourceManager, quietCleanup)
 		return nil, err
@@ -217,8 +230,8 @@ func (b *ImageBuilder) setupBuild(config builder.Config) (*builder.Target, error
 }
 
 // createBuildResources creates all necessary AWS resources for the build
-func (b *ImageBuilder) createBuildResources(ctx context.Context, config builder.Config, amiTarget *builder.Target, created *CreatedResources) (*buildResources, error) {
-	componentARNs, err := b.createComponents(ctx, config, created)
+func (b *ImageBuilder) createBuildResources(ctx context.Context, config builder.Config, amiTarget *builder.Target, created *CreatedResources, stagedFiles map[int]*StagedFile) (*buildResources, error) {
+	componentARNs, err := b.createComponents(ctx, config, created, stagedFiles)
 	if err != nil {
 		return nil, WrapWithRemediation(err, "failed to create components")
 	}
@@ -294,6 +307,58 @@ func (b *ImageBuilder) finalizeBuild(ctx context.Context, amiID string, target *
 	}
 }
 
+// stageFileProvisioners uploads any `file` provisioner sources to the
+// configured S3 staging bucket so the build instance can fetch them via
+// S3Download. Returns a map keyed by provisioner index. If no `file`
+// provisioners are present, returns an empty map and no error.
+func (b *ImageBuilder) stageFileProvisioners(ctx context.Context, cfg builder.Config) (map[int]*StagedFile, error) {
+	staged := make(map[int]*StagedFile)
+
+	hasFileProvisioner := false
+	for _, prov := range cfg.Provisioners {
+		if prov.Type == "file" {
+			hasFileProvisioner = true
+			break
+		}
+	}
+	if !hasFileProvisioner {
+		return staged, nil
+	}
+
+	if b.fileStager == nil {
+		return nil, fmt.Errorf("file provisioner requires aws.ami.file_staging_bucket to be configured")
+	}
+
+	for i, prov := range cfg.Provisioners {
+		if prov.Type != "file" {
+			continue
+		}
+		if prov.Source == "" {
+			return nil, fmt.Errorf("file provisioner %d: source is required", i)
+		}
+		keyPrefix := fmt.Sprintf("warpgate-staging/%s/%d", b.buildID, i)
+		s, err := b.fileStager.Stage(ctx, prov.Source, keyPrefix)
+		if err != nil {
+			b.cleanupStagedFiles(ctx, staged)
+			return nil, fmt.Errorf("stage file provisioner %d: %w", i, err)
+		}
+		staged[i] = s
+	}
+	return staged, nil
+}
+
+// cleanupStagedFiles removes any S3 objects uploaded for `file` provisioners.
+// Errors are logged inside FileStager.Cleanup; we never fail the build over
+// orphaned staging objects.
+func (b *ImageBuilder) cleanupStagedFiles(ctx context.Context, staged map[int]*StagedFile) {
+	if b.fileStager == nil {
+		return
+	}
+	for _, s := range staged {
+		b.fileStager.Cleanup(ctx, s)
+	}
+}
+
 // Share implements the AMIBuilder interface
 func (b *ImageBuilder) Share(ctx context.Context, amiID string, accountIDs []string) error {
 	return b.operations.ShareAMI(ctx, amiID, accountIDs)
@@ -331,7 +396,7 @@ func (b *ImageBuilder) Close() error {
 }
 
 // createComponents creates Image Builder components from provisioners in parallel using errgroup
-func (b *ImageBuilder) createComponents(ctx context.Context, config builder.Config, created *CreatedResources) ([]string, error) {
+func (b *ImageBuilder) createComponents(ctx context.Context, config builder.Config, created *CreatedResources, stagedFiles map[int]*StagedFile) ([]string, error) {
 	numProvisioners := len(config.Provisioners)
 	if numProvisioners == 0 {
 		return nil, nil
@@ -368,7 +433,12 @@ func (b *ImageBuilder) createComponents(ctx context.Context, config builder.Conf
 				}
 			}
 
-			arn, err := b.componentGen.GenerateComponent(ctx, prov, componentName, version)
+			opts := GenerateComponentOpts{}
+			if staged, ok := stagedFiles[index]; ok {
+				opts.StagedFile = staged
+			}
+
+			arn, err := b.componentGen.GenerateComponent(ctx, prov, componentName, version, opts)
 			if err != nil {
 				return fmt.Errorf("failed to create component %d (%s): %w", index, prov.Type, err)
 			}

--- a/builder/ami/imagebuilder_test.go
+++ b/builder/ami/imagebuilder_test.go
@@ -36,6 +36,7 @@ import (
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/aws/aws-sdk-go-v2/service/imagebuilder"
 	ibtypes "github.com/aws/aws-sdk-go-v2/service/imagebuilder/types"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/aws-sdk-go-v2/service/ssm"
 	ssmtypes "github.com/aws/aws-sdk-go-v2/service/ssm/types"
 	"github.com/cowdogmoo/warpgate/v3/builder"
@@ -3324,4 +3325,110 @@ func TestOptimizedResourceCleanup_RecipeARNError(t *testing.T) {
 	bo := NewBatchOperations(clients)
 	err := bo.OptimizedResourceCleanup(context.Background(), "test")
 	assert.NoError(t, err)
+}
+
+func TestStageFileProvisioners_NoFileProvisioners(t *testing.T) {
+	t.Parallel()
+
+	ib := &ImageBuilder{buildID: "build-1"}
+	cfg := builder.Config{
+		Provisioners: []builder.Provisioner{
+			{Type: "shell", Inline: []string{"echo hi"}},
+		},
+	}
+
+	staged, err := ib.stageFileProvisioners(context.Background(), cfg)
+	require.NoError(t, err)
+	assert.Empty(t, staged)
+}
+
+func TestStageFileProvisioners_MissingStagingBucket(t *testing.T) {
+	t.Parallel()
+
+	ib := &ImageBuilder{buildID: "build-1"}
+	cfg := builder.Config{
+		Provisioners: []builder.Provisioner{
+			{Type: "file", Source: "/tmp/x", Destination: "/dst"},
+		},
+	}
+
+	_, err := ib.stageFileProvisioners(context.Background(), cfg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "file_staging_bucket")
+}
+
+func TestStageFileProvisioners_MissingSource(t *testing.T) {
+	t.Parallel()
+
+	ib := &ImageBuilder{
+		buildID:    "build-1",
+		fileStager: NewFileStager(&MockS3Client{}, "bkt"),
+	}
+	cfg := builder.Config{
+		Provisioners: []builder.Provisioner{
+			{Type: "file", Destination: "/dst"},
+		},
+	}
+
+	_, err := ib.stageFileProvisioners(context.Background(), cfg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "source is required")
+}
+
+func TestStageFileProvisioners_Stages(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	src1 := filepath.Join(dir, "a.txt")
+	src2 := filepath.Join(dir, "b.txt")
+	require.NoError(t, os.WriteFile(src1, []byte("a"), 0o600))
+	require.NoError(t, os.WriteFile(src2, []byte("b"), 0o600))
+
+	mock := &MockS3Client{}
+	ib := &ImageBuilder{
+		buildID:    "build-99",
+		fileStager: NewFileStager(mock, "bkt"),
+	}
+	cfg := builder.Config{
+		Provisioners: []builder.Provisioner{
+			{Type: "shell", Inline: []string{"echo"}},
+			{Type: "file", Source: src1, Destination: "/dst/a"},
+			{Type: "file", Source: src2, Destination: "/dst/b"},
+		},
+	}
+
+	staged, err := ib.stageFileProvisioners(context.Background(), cfg)
+	require.NoError(t, err)
+	require.Len(t, staged, 2)
+	assert.Equal(t, "warpgate-staging/build-99/1/", staged[1].KeyPrefix)
+	assert.Equal(t, "warpgate-staging/build-99/2/", staged[2].KeyPrefix)
+	assert.Equal(t, "a.txt", staged[1].BaseName)
+	assert.Equal(t, "b.txt", staged[2].BaseName)
+}
+
+func TestCleanupStagedFiles_NoStager(t *testing.T) {
+	t.Parallel()
+
+	ib := &ImageBuilder{}
+	ib.cleanupStagedFiles(context.Background(), map[int]*StagedFile{
+		0: {Bucket: "b", BaseName: "f"},
+	})
+}
+
+func TestCleanupStagedFiles_DeletesAll(t *testing.T) {
+	t.Parallel()
+
+	var deletes atomic.Int32
+	mock := &MockS3Client{}
+	mock.DeleteObjectFunc = func(_ context.Context, _ *s3.DeleteObjectInput, _ ...func(*s3.Options)) (*s3.DeleteObjectOutput, error) {
+		deletes.Add(1)
+		return &s3.DeleteObjectOutput{}, nil
+	}
+
+	ib := &ImageBuilder{fileStager: NewFileStager(mock, "bkt")}
+	ib.cleanupStagedFiles(context.Background(), map[int]*StagedFile{
+		0: {Bucket: "bkt", KeyPrefix: "p/", BaseName: "a"},
+		1: {Bucket: "bkt", KeyPrefix: "q/", BaseName: "b"},
+	})
+	assert.Equal(t, int32(2), deletes.Load())
 }

--- a/builder/ami/imagebuilder_test.go
+++ b/builder/ami/imagebuilder_test.go
@@ -227,7 +227,7 @@ func TestComponentDocument(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			gen := &ComponentGenerator{}
-			_, err := gen.createComponentDocument(tt.provisioner)
+			_, err := gen.createComponentDocument(tt.provisioner, GenerateComponentOpts{})
 			if (err != nil) != tt.wantErr {
 				t.Errorf("createComponentDocument() error = %v, wantErr %v", err, tt.wantErr)
 			}
@@ -308,7 +308,7 @@ func TestPowerShellComponent(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			gen := &ComponentGenerator{}
-			doc, err := gen.createComponentDocument(tt.provisioner)
+			doc, err := gen.createComponentDocument(tt.provisioner, GenerateComponentOpts{})
 			if (err != nil) != tt.wantErr {
 				t.Errorf("createComponentDocument() error = %v, wantErr %v", err, tt.wantErr)
 			}
@@ -1677,7 +1677,7 @@ func TestCreateComponents_NoProvisioners(t *testing.T) {
 	arns, err := ib.createComponents(context.Background(), builder.Config{
 		Name:         "test",
 		Provisioners: []builder.Provisioner{},
-	}, &CreatedResources{})
+	}, &CreatedResources{}, nil)
 
 	assert.NoError(t, err)
 	assert.Nil(t, arns)
@@ -1712,7 +1712,7 @@ func TestCreateComponents_Success(t *testing.T) {
 			{Type: "shell", Inline: []string{"echo hello"}},
 			{Type: "shell", Inline: []string{"echo world"}},
 		},
-	}, created)
+	}, created, nil)
 
 	require.NoError(t, err)
 	assert.Len(t, arns, 2)
@@ -1754,7 +1754,7 @@ func TestCreateComponents_PartialFailure(t *testing.T) {
 			{Type: "shell", Inline: []string{"echo hello"}},
 			{Type: "shell", Inline: []string{"echo world"}},
 		},
-	}, created)
+	}, created, nil)
 
 	assert.Error(t, err)
 	assert.Nil(t, arns)
@@ -3221,7 +3221,7 @@ func TestCreateBuildResources_ComponentFailure(t *testing.T) {
 		Provisioners: []builder.Provisioner{
 			{Type: "shell", Inline: []string{"echo hello"}},
 		},
-	}, &builder.Target{Region: "us-east-1"}, created)
+	}, &builder.Target{Region: "us-east-1"}, created, nil)
 
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to create components")

--- a/config/config.go
+++ b/config/config.go
@@ -149,6 +149,11 @@ type AMIConfig struct {
 	// InstanceProfileName is the IAM instance profile for EC2 Image Builder
 	// The instance profile grants permissions to the build instance
 	InstanceProfileName string `mapstructure:"instance_profile_name"`
+	// FileStagingBucket is the S3 bucket warpgate uploads `file` provisioner
+	// sources to before the build starts. Required when any provisioner has
+	// type=file. The InstanceProfileName must grant s3:GetObject on this
+	// bucket so the build instance can pull the staged objects.
+	FileStagingBucket string `mapstructure:"file_staging_bucket"`
 }
 
 // ContainerConfig holds container build configuration

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ec2 v1.299.0
 	github.com/aws/aws-sdk-go-v2/service/iam v1.53.8
 	github.com/aws/aws-sdk-go-v2/service/imagebuilder v1.53.0
+	github.com/aws/aws-sdk-go-v2/service/s3 v1.100.0
 	github.com/aws/aws-sdk-go-v2/service/ssm v1.68.5
 	github.com/docker/cli v29.4.1+incompatible
 	github.com/fatih/color v1.19.0
@@ -35,6 +36,11 @@ require (
 	google.golang.org/grpc v1.80.0
 	gopkg.in/ini.v1 v1.67.1
 	gopkg.in/yaml.v3 v3.0.1
+)
+
+require (
+	github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.9.14 // indirect
+	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.22 // indirect
 )
 
 require (
@@ -70,6 +76,7 @@ require (
 	github.com/containerd/stargz-snapshotter/estargz v0.18.2 // indirect
 	github.com/containerd/ttrpc v1.2.8 // indirect
 	github.com/containerd/typeurl/v2 v2.2.3 // indirect
+	github.com/cowdogmoo/bcp v1.1.0
 	github.com/cyphar/filepath-securejoin v0.6.1 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/distribution/reference v0.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -49,8 +49,14 @@ github.com/aws/aws-sdk-go-v2/service/imagebuilder v1.53.0 h1:NHbpkSrBRuFXKDg1jzV
 github.com/aws/aws-sdk-go-v2/service/imagebuilder v1.53.0/go.mod h1:x2SBKHwQucGurrKGBFjQs6wKKdDw8fIdoQEJOSelypo=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.8 h1:HtOTYcbVcGABLOVuPYaIihj6IlkqubBwFj10K5fxRek=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.8/go.mod h1:VsK9abqQeGlzPgUr+isNWzPlK2vKe9INMLWnY65f5Xs=
+github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.9.14 h1:xnvDEnw+pnj5mctWiYuFbigrEzSm35x7k4KS/ZkCANg=
+github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.9.14/go.mod h1:yS5rNogD8e0Wu9+l3MUwr6eENBzEeGejvINpN5PAYfY=
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.22 h1:PUmZeJU6Y1Lbvt9WFuJ0ugUK2xn6hIWUBBbKuOWF30s=
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.22/go.mod h1:nO6egFBoAaoXze24a2C0NjQCvdpk8OueRoYimvEB9jo=
+github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.22 h1:SE+aQ4DEqG53RRCAIHlCf//B2ycxGH7jFkpnAh/kKPM=
+github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.22/go.mod h1:ES3ynECd7fYeJIL6+oax+uIEljmfps0S70BaQzbMd/o=
+github.com/aws/aws-sdk-go-v2/service/s3 v1.100.0 h1:7G26Sae6PMKn4kMcU5JzNfrm1YrKwyOhowXPYR2WiWY=
+github.com/aws/aws-sdk-go-v2/service/s3 v1.100.0/go.mod h1:Fw9aqhJicIVee1VytBBjH+l+5ov6/PhbtIK/u3rt/ls=
 github.com/aws/aws-sdk-go-v2/service/signin v1.0.10 h1:a1Fq/KXn75wSzoJaPQTgZO0wHGqE9mjFnylnqEPTchA=
 github.com/aws/aws-sdk-go-v2/service/signin v1.0.10/go.mod h1:p6+MXNxW7IA6dMgHfTAzljuwSKD0NCm/4lbS4t6+7vI=
 github.com/aws/aws-sdk-go-v2/service/ssm v1.68.5 h1:TY5Vh7uXQgJVuc6ahI6toLcRajG1aYSDCP3a0xsPvmo=
@@ -103,6 +109,8 @@ github.com/containerd/ttrpc v1.2.8 h1:xbVu6D4qF2jihdh9rDVOKqUMiFBQk6YctTdo1zk087
 github.com/containerd/ttrpc v1.2.8/go.mod h1:wyZW2K79t4Hfcxl+GUvkZqRBzJlqFFvgEeeWXa42tyE=
 github.com/containerd/typeurl/v2 v2.2.3 h1:yNA/94zxWdvYACdYO8zofhrTVuQY73fFU1y++dYSw40=
 github.com/containerd/typeurl/v2 v2.2.3/go.mod h1:95ljDnPfD3bAbDJRugOiShd/DlAAsxGtUBhJxIn7SCk=
+github.com/cowdogmoo/bcp v1.1.0 h1:r4m5TDpv6yy7VQ1R/SX3OJOBhNC4DT9OJOoKTeZGRXk=
+github.com/cowdogmoo/bcp v1.1.0/go.mod h1:7g4gfcnypJiAzWzggHzYoxAcwK1btNKn3UcwovQi+jE=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/cyphar/filepath-securejoin v0.6.1 h1:5CeZ1jPXEiYt3+Z6zqprSAgSWiggmpVyciv8syjIpVE=
 github.com/cyphar/filepath-securejoin v0.6.1/go.mod h1:A8hd4EnAeyujCJRrICiOWqjS1AX0a9kM5XL+NwKoYSc=


### PR DESCRIPTION
**Key Changes:**

- Introduced S3 file staging for `file` provisioners, enabling secure upload and retrieval during AMI builds
- Added `file_staging_bucket` configuration to specify S3 bucket for staged files
- Refactored component generation to support S3Download steps for file provisioners
- Expanded tests to cover file provisioner staging and error scenarios

**Added:**

- S3API interface and S3 client integration for S3 operations in `aws_interfaces.go` and `client.go`
- `FileStager` utility to handle upload and cleanup of provisioner sources to S3, with logic in new `file_stager.go`
- `GenerateComponentOpts` struct to pass staged file context into component generation
- `createFileComponent` method in `component.go` for generating S3Download Image Builder components referencing staged S3 objects
- Unit tests in `component_test.go` for file provisioner handling, including directory, missing staging, and error cases
- `file_staging_bucket` field in `AMIConfig` (config.go) for S3 bucket configuration

**Changed:**

- `ImageBuilder` logic in `imagebuilder.go` to stage file provisioners before resource creation and clean up afterward
- Component generation and resource creation flows to pass staged file context and handle errors if staging is not configured or fails
- Updated method signatures in `component.go`, `imagebuilder.go`, and corresponding tests to support new options and staged file handling
- Dependency management in `go.mod` and `go.sum` to add AWS S3 SDK and `github.com/cowdogmoo/bcp` for S3 file transfers

**Removed:**

- Assumption that file provisioners can reference local sources directly; now all must be staged to S3 for AMI builds