### PR TITLE
feat: add validation for file provisioner in AMI builder

### DIFF
--- a/builder/ami/validation.go
+++ b/builder/ami/validation.go
@@ -623,9 +623,25 @@ func (v *Validator) validateProvisioners(result *ValidationResult, config builde
 			} else {
 				result.AddInfo("Provisioner %d: powershell with %d scripts", i, len(p.PSScripts))
 			}
+		case "file":
+			validateFileProvisioner(result, i, p)
 		default:
 			result.AddError("Provisioner %d: unknown type '%s'", i, p.Type)
 		}
+	}
+}
+
+// validateFileProvisioner validates a `file` provisioner's source and destination.
+func validateFileProvisioner(result *ValidationResult, i int, p builder.Provisioner) {
+	switch {
+	case p.Source == "" && p.Destination == "":
+		result.AddError("Provisioner %d (file): source and destination are required", i)
+	case p.Source == "":
+		result.AddError("Provisioner %d (file): source is required", i)
+	case p.Destination == "":
+		result.AddError("Provisioner %d (file): destination is required", i)
+	default:
+		result.AddInfo("Provisioner %d: file %s -> %s (staged via aws.ami.file_staging_bucket)", i, p.Source, p.Destination)
 	}
 }
 

--- a/builder/ami/validation_test.go
+++ b/builder/ami/validation_test.go
@@ -213,6 +213,37 @@ func TestValidateProvisioners(t *testing.T) {
 			wantInfoCount: 1,
 		},
 		{
+			name: "valid file provisioner",
+			provisioners: []builder.Provisioner{
+				{Type: "file", Source: "./local.txt", Destination: "/etc/app/local.txt"},
+			},
+			wantInfoCount: 2,
+		},
+		{
+			name: "file without source errors",
+			provisioners: []builder.Provisioner{
+				{Type: "file", Destination: "/etc/app/local.txt"},
+			},
+			wantErrors:    1,
+			wantInfoCount: 1,
+		},
+		{
+			name: "file without destination errors",
+			provisioners: []builder.Provisioner{
+				{Type: "file", Source: "./local.txt"},
+			},
+			wantErrors:    1,
+			wantInfoCount: 1,
+		},
+		{
+			name: "file without source or destination errors",
+			provisioners: []builder.Provisioner{
+				{Type: "file"},
+			},
+			wantErrors:    1,
+			wantInfoCount: 1,
+		},
+		{
 			name: "unknown provisioner type errors",
 			provisioners: []builder.Provisioner{
 				{Type: "terraform"},


### PR DESCRIPTION
**Key Changes:**

- Implemented validation logic for file provisioner source and destination fields
- Added dedicated function to handle file provisioner validation cases
- Expanded unit tests to cover file provisioner validation scenarios

**Added:**

- File provisioner validation - Introduced `validateFileProvisioner` function to ensure both `source` and `destination` are provided for file provisioners in `validation.go`
- Unit tests for file provisioner - Added multiple test cases in `validation_test.go` to verify correct error and info reporting for valid and invalid file provisioner configurations

**Changed:**

- Provisioner validation switch - Updated `validateProvisioners` logic to invoke `validateFileProvisioner` when encountering a file provisioner type, improving validation coverage and maintainability