### PR TITLE
feat: add support for local directory sources in template sources

### DIFF
--- a/builder/config.go
+++ b/builder/config.go
@@ -246,6 +246,7 @@ type ImageAuth struct {
 
 // Source defines an external source to fetch before the build starts
 // Sources are fetched to a temporary directory and can be referenced by provisioners
+// Exactly one of Git or Local must be specified.
 type Source struct {
 	// Name is a unique identifier for this source, used to reference it in provisioners
 	// Reference sources in provisioners using ${sources.<name>}
@@ -254,8 +255,21 @@ type Source struct {
 	// Git specifies a git repository to clone
 	Git *GitSource `yaml:"git,omitempty" json:"git,omitempty"`
 
+	// Local specifies a directory on the local filesystem
+	// Useful when provisioner assets live in the same repository as the template
+	Local *LocalSource `yaml:"local,omitempty" json:"local,omitempty"`
+
 	// Path is populated at runtime with the local path where the source was fetched
 	Path string `yaml:"-" json:"-"`
+}
+
+// LocalSource defines a directory on the local filesystem to use as a source.
+// Relative paths are resolved relative to the directory containing the template config file.
+type LocalSource struct {
+	// Path is the directory to use as the source
+	// Relative paths are resolved relative to the template config file's directory
+	// Examples: "./ansible", "../shared/playbooks", "/abs/path/to/dir"
+	Path string `yaml:"path" json:"path"`
 }
 
 // GitSource defines a git repository to clone

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -618,6 +618,11 @@ func TestLoad_FindsConfigInCurrentDir(t *testing.T) {
 		t.Fatalf("Failed to write test config: %v", err)
 	}
 
+	isolated := t.TempDir()
+	t.Setenv("HOME", isolated)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(isolated, ".config"))
+	t.Setenv("XDG_CACHE_HOME", filepath.Join(isolated, ".cache"))
+
 	originalDir, _ := os.Getwd()
 	defer func() {
 		_ = os.Chdir(originalDir)
@@ -642,6 +647,12 @@ func TestLoad_FindsConfigInCurrentDir(t *testing.T) {
 // TestLoad_NoConfigFile tests Load with no config file returns defaults + ErrConfigNotFound
 func TestLoad_NoConfigFile(t *testing.T) {
 	tmpDir := t.TempDir()
+
+	isolated := t.TempDir()
+	t.Setenv("HOME", isolated)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(isolated, ".config"))
+	t.Setenv("XDG_CACHE_HOME", filepath.Join(isolated, ".cache"))
+
 	originalDir, _ := os.Getwd()
 	defer func() {
 		_ = os.Chdir(originalDir)

--- a/config/paths_test.go
+++ b/config/paths_test.go
@@ -66,6 +66,11 @@ func TestGetCacheDir(t *testing.T) {
 		configContent := "templates:\n  cache_dir: " + customCacheDir + "\n"
 		require.NoError(t, os.WriteFile(configPath, []byte(configContent), 0644))
 
+		isolated := t.TempDir()
+		t.Setenv("HOME", isolated)
+		t.Setenv("XDG_CONFIG_HOME", filepath.Join(isolated, ".config"))
+		t.Setenv("XDG_CACHE_HOME", filepath.Join(isolated, ".cache"))
+
 		// Change to directory with config so Load() picks it up
 		originalDir, _ := os.Getwd()
 		defer func() { _ = os.Chdir(originalDir) }()

--- a/config/viper_test.go
+++ b/config/viper_test.go
@@ -23,6 +23,7 @@ THE SOFTWARE.
 package config
 
 import (
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -30,7 +31,11 @@ import (
 )
 
 func TestNewConfigViper(t *testing.T) {
-	t.Parallel()
+	isolated := t.TempDir()
+	t.Setenv("HOME", isolated)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(isolated, ".config"))
+	t.Setenv("XDG_CACHE_HOME", filepath.Join(isolated, ".cache"))
+	t.Chdir(isolated)
 
 	v := NewConfigViper()
 	require.NotNil(t, v)

--- a/git/sources.go
+++ b/git/sources.go
@@ -49,6 +49,9 @@ const (
 
 type SourceFetcher struct {
 	BaseDir string
+	// ConfigFilePath is the path to the template config file.
+	// Used to resolve relative paths in local sources.
+	ConfigFilePath string
 }
 
 // If baseDir is empty, a temporary directory will be created
@@ -81,9 +84,42 @@ func (f *SourceFetcher) fetchSource(ctx context.Context, source *builder.Source)
 	if source.Git != nil {
 		return f.fetchGitSource(ctx, source)
 	}
+	if source.Local != nil {
+		return f.fetchLocalSource(ctx, source)
+	}
 
 	// Future: support other source types (http, s3, etc.)
-	return fmt.Errorf("source %q has no valid source type defined (git, etc.)", source.Name)
+	return fmt.Errorf("source %q has no valid source type defined (git, local, etc.)", source.Name)
+}
+
+func (f *SourceFetcher) fetchLocalSource(ctx context.Context, source *builder.Source) error {
+	local := source.Local
+
+	resolved := expandPath(local.Path)
+	if !filepath.IsAbs(resolved) {
+		baseDir := "."
+		if f.ConfigFilePath != "" {
+			baseDir = filepath.Dir(f.ConfigFilePath)
+		}
+		resolved = filepath.Join(baseDir, resolved)
+	}
+
+	absPath, err := filepath.Abs(resolved)
+	if err != nil {
+		return fmt.Errorf("failed to resolve local source path %q: %w", local.Path, err)
+	}
+
+	info, err := os.Stat(absPath)
+	if err != nil {
+		return fmt.Errorf("failed to access local source path %q: %w", absPath, err)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("local source path %q is not a directory", absPath)
+	}
+
+	source.Path = absPath
+	logging.InfoContext(ctx, "Resolved local source %s at %s", source.Name, absPath)
+	return nil
 }
 
 func (f *SourceFetcher) fetchGitSource(ctx context.Context, source *builder.Source) error {
@@ -278,6 +314,7 @@ func FetchSourcesWithCleanup(ctx context.Context, sources []builder.Source, conf
 	if err != nil {
 		return nil, fmt.Errorf("failed to create source fetcher: %w", err)
 	}
+	fetcher.ConfigFilePath = configFilePath
 
 	if err := fetcher.FetchSources(ctx, sources); err != nil {
 		_ = fetcher.Cleanup()

--- a/git/sources_test.go
+++ b/git/sources_test.go
@@ -2292,3 +2292,117 @@ func TestGetGitAuth_EmptyAuth(t *testing.T) {
 	require.NoError(t, err)
 	assert.Nil(t, auth)
 }
+
+func TestFetchLocalSource_AbsolutePath(t *testing.T) {
+	t.Parallel()
+
+	srcDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(srcDir, "playbook.yml"), []byte("- hosts: all"), 0644))
+
+	fetcher, err := NewSourceFetcher(t.TempDir())
+	require.NoError(t, err)
+
+	source := &builder.Source{
+		Name:  "ansible",
+		Local: &builder.LocalSource{Path: srcDir},
+	}
+
+	require.NoError(t, fetcher.fetchLocalSource(context.Background(), source))
+
+	expected, err := filepath.Abs(srcDir)
+	require.NoError(t, err)
+	assert.Equal(t, expected, source.Path)
+}
+
+func TestFetchLocalSource_RelativePathResolvesToConfigDir(t *testing.T) {
+	t.Parallel()
+
+	configDir := t.TempDir()
+	ansibleDir := filepath.Join(configDir, "ansible")
+	require.NoError(t, os.MkdirAll(ansibleDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(ansibleDir, "site.yml"), []byte(""), 0644))
+
+	fetcher, err := NewSourceFetcher(t.TempDir())
+	require.NoError(t, err)
+	fetcher.ConfigFilePath = filepath.Join(configDir, "warpgate.yaml")
+
+	source := &builder.Source{
+		Name:  "ansible",
+		Local: &builder.LocalSource{Path: "./ansible"},
+	}
+
+	require.NoError(t, fetcher.fetchLocalSource(context.Background(), source))
+
+	expected, err := filepath.Abs(ansibleDir)
+	require.NoError(t, err)
+	assert.Equal(t, expected, source.Path)
+}
+
+func TestFetchLocalSource_MissingDirectory(t *testing.T) {
+	t.Parallel()
+
+	fetcher, err := NewSourceFetcher(t.TempDir())
+	require.NoError(t, err)
+
+	source := &builder.Source{
+		Name:  "missing",
+		Local: &builder.LocalSource{Path: "/definitely/does/not/exist/warpgate-test"},
+	}
+
+	err = fetcher.fetchLocalSource(context.Background(), source)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to access local source path")
+}
+
+func TestFetchLocalSource_NotADirectory(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	filePath := filepath.Join(tmpDir, "file.txt")
+	require.NoError(t, os.WriteFile(filePath, []byte("hi"), 0644))
+
+	fetcher, err := NewSourceFetcher(t.TempDir())
+	require.NoError(t, err)
+
+	source := &builder.Source{
+		Name:  "is-file",
+		Local: &builder.LocalSource{Path: filePath},
+	}
+
+	err = fetcher.fetchLocalSource(context.Background(), source)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "is not a directory")
+}
+
+func TestFetchSourcesWithCleanup_LocalSource_CopiedIntoBuildContext(t *testing.T) {
+	t.Parallel()
+
+	configDir := t.TempDir()
+	configPath := filepath.Join(configDir, "warpgate.yaml")
+	require.NoError(t, os.WriteFile(configPath, []byte(""), 0644))
+
+	ansibleDir := filepath.Join(configDir, "ansible")
+	require.NoError(t, os.MkdirAll(ansibleDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(ansibleDir, "playbook.yml"), []byte("- hosts: all"), 0644))
+
+	sources := []builder.Source{
+		{
+			Name:  "ansible",
+			Local: &builder.LocalSource{Path: "./ansible"},
+		},
+	}
+
+	cleanup, err := FetchSourcesWithCleanup(context.Background(), sources, configPath)
+	require.NoError(t, err)
+	defer cleanup()
+
+	assert.NotEmpty(t, sources[0].Path)
+	assert.DirExists(t, sources[0].Path)
+	assert.FileExists(t, filepath.Join(sources[0].Path, "playbook.yml"))
+
+	// Source should have been copied into the build-context sources dir
+	expectedCopiedRoot := filepath.Join(configDir, sourcesLocalDirName, "ansible")
+	expectedAbs, err := filepath.Abs(expectedCopiedRoot)
+	require.NoError(t, err)
+	assert.Equal(t, expectedAbs, sources[0].Path)
+}

--- a/schema/warpgate-template.json
+++ b/schema/warpgate-template.json
@@ -315,6 +315,20 @@
       "type": "object",
       "description": "ImageAuth contains authentication information for pulling images"
     },
+    "LocalSource": {
+      "properties": {
+        "path": {
+          "type": "string",
+          "description": "Path is the directory to use as the source\nRelative paths are resolved relative to the template config file's directory\nExamples: \"./ansible\", \"../shared/playbooks\", \"/abs/path/to/dir\""
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "path"
+      ],
+      "description": "LocalSource defines a directory on the local filesystem to use as a source."
+    },
     "Metadata": {
       "properties": {
         "name": {
@@ -521,6 +535,10 @@
         "git": {
           "$ref": "#/$defs/GitSource",
           "description": "Git specifies a git repository to clone"
+        },
+        "local": {
+          "$ref": "#/$defs/LocalSource",
+          "description": "Local specifies a directory on the local filesystem\nUseful when provisioner assets live in the same repository as the template"
         }
       },
       "additionalProperties": false,
@@ -528,7 +546,7 @@
       "required": [
         "name"
       ],
-      "description": "Source defines an external source to fetch before the build starts Sources are fetched to a temporary directory and can be referenced by provisioners"
+      "description": "Source defines an external source to fetch before the build starts Sources are fetched to a temporary directory and can be referenced by provisioners Exactly one of Git or Local must be specified."
     },
     "Target": {
       "properties": {

--- a/templates/config_validator.go
+++ b/templates/config_validator.go
@@ -469,7 +469,8 @@ func validateSourceName(name string, index int, seenNames map[string]bool) error
 		isLower := r >= 'a' && r <= 'z'
 		isUpper := r >= 'A' && r <= 'Z'
 		isDigit := r >= '0' && r <= '9'
-		if !(isLower || isUpper || isDigit || r == '-' || r == '_') {
+		isValid := isLower || isUpper || isDigit || r == '-' || r == '_'
+		if !isValid {
 			return fmt.Errorf("sources[%d]: name %q contains invalid characters (use alphanumeric, hyphens, underscores)", index, name)
 		}
 	}

--- a/templates/config_validator.go
+++ b/templates/config_validator.go
@@ -432,40 +432,76 @@ func (v *Validator) validateTarget(target *builder.Target, index int) error {
 
 // validateSource validates a single source definition
 func (v *Validator) validateSource(ctx context.Context, source *builder.Source, index int, seenNames map[string]bool) error {
-	// Name is required
-	if source.Name == "" {
-		return fmt.Errorf("sources[%d]: name is required", index)
+	if err := validateSourceName(source.Name, index, seenNames); err != nil {
+		return err
 	}
 
-	// Check for duplicate names
-	if seenNames[source.Name] {
-		return fmt.Errorf("sources[%d]: duplicate source name %q", index, source.Name)
-	}
-	seenNames[source.Name] = true
-
-	// Validate source name format (alphanumeric, hyphens, underscores)
-	for _, r := range source.Name {
-		isLower := r >= 'a' && r <= 'z'
-		isUpper := r >= 'A' && r <= 'Z'
-		isDigit := r >= '0' && r <= '9'
-		isValid := isLower || isUpper || isDigit || r == '-' || r == '_'
-		if !isValid {
-			return fmt.Errorf("sources[%d]: name %q contains invalid characters (use alphanumeric, hyphens, underscores)", index, source.Name)
-		}
+	if err := validateSourceTypeCardinality(source, index); err != nil {
+		return err
 	}
 
-	// Must have at least one source type defined
-	if source.Git == nil {
-		return fmt.Errorf("sources[%d]: must specify a source type (git)", index)
-	}
-
-	// Validate git source
 	if source.Git != nil {
 		if err := v.validateGitSource(ctx, source.Git, index); err != nil {
 			return err
 		}
 	}
 
+	if source.Local != nil {
+		if err := v.validateLocalSource(source.Local, index); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// validateSourceName checks the source name is non-empty, unique, and uses a valid character set.
+func validateSourceName(name string, index int, seenNames map[string]bool) error {
+	if name == "" {
+		return fmt.Errorf("sources[%d]: name is required", index)
+	}
+	if seenNames[name] {
+		return fmt.Errorf("sources[%d]: duplicate source name %q", index, name)
+	}
+	seenNames[name] = true
+
+	for _, r := range name {
+		isLower := r >= 'a' && r <= 'z'
+		isUpper := r >= 'A' && r <= 'Z'
+		isDigit := r >= '0' && r <= '9'
+		if !(isLower || isUpper || isDigit || r == '-' || r == '_') {
+			return fmt.Errorf("sources[%d]: name %q contains invalid characters (use alphanumeric, hyphens, underscores)", index, name)
+		}
+	}
+	return nil
+}
+
+// validateSourceTypeCardinality enforces that exactly one source type is set.
+func validateSourceTypeCardinality(source *builder.Source, index int) error {
+	typesSet := 0
+	if source.Git != nil {
+		typesSet++
+	}
+	if source.Local != nil {
+		typesSet++
+	}
+	switch typesSet {
+	case 0:
+		return fmt.Errorf("sources[%d]: must specify a source type (git, local)", index)
+	case 1:
+		return nil
+	default:
+		return fmt.Errorf("sources[%d]: only one source type may be specified (git, local)", index)
+	}
+}
+
+// validateLocalSource validates a local source configuration.
+// Path existence is not checked here — that happens at fetch time, since
+// validation may run in lint contexts where the path is not yet available.
+func (v *Validator) validateLocalSource(local *builder.LocalSource, index int) error {
+	if local.Path == "" {
+		return fmt.Errorf("sources[%d].local: path is required", index)
+	}
 	return nil
 }
 

--- a/templates/config_validator_test.go
+++ b/templates/config_validator_test.go
@@ -973,6 +973,39 @@ func TestValidator_ValidateSource(t *testing.T) {
 			},
 			shouldError: false,
 		},
+		{
+			name: "Valid local source",
+			sources: []builder.Source{
+				{
+					Name:  "ansible",
+					Local: &builder.LocalSource{Path: "./ansible"},
+				},
+			},
+			shouldError: false,
+		},
+		{
+			name: "Local source without path",
+			sources: []builder.Source{
+				{
+					Name:  "ansible",
+					Local: &builder.LocalSource{},
+				},
+			},
+			shouldError: true,
+			errContains: "local: path is required",
+		},
+		{
+			name: "Both git and local set",
+			sources: []builder.Source{
+				{
+					Name:  "conflict",
+					Git:   &builder.GitSource{Repository: "https://github.com/org/repo.git"},
+					Local: &builder.LocalSource{Path: "./ansible"},
+				},
+			},
+			shouldError: true,
+			errContains: "only one source type",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
**Key Changes:**

- Introduced support for specifying local directories as external sources for builds
- Updated validation logic to enforce exactly one source type (git or local)
- Added comprehensive tests for local source resolution and validation
- Extended JSON schema and documentation for local source support

**Added:**

- Local source configuration - Added `LocalSource` struct in `builder/config.go` to represent a directory on the local filesystem, with clear documentation and path resolution logic
- Local source fetching - Implemented `fetchLocalSource` method in `git/sources.go` to resolve, validate, and use local directories as sources, supporting both absolute and relative paths
- Validation for local sources - Extended the validator in `templates/config_validator.go` to handle local sources, enforce required fields, and check cardinality between git and local
- Unit tests for local sources - Added comprehensive tests in `git/sources_test.go` and `templates/config_validator_test.go` to cover absolute/relative path resolution, error handling, and validator edge cases
- JSON schema extension - Updated `schema/warpgate-template.json` to include the `LocalSource` definition and allow "local" as a valid source type

**Changed:**

- Source type validation - Refactored source validation logic in `templates/config_validator.go` to ensure exactly one of git or local is set, improving error messaging and robustness
- Test environment isolation - Updated various config and path-related tests (`config_test.go`, `paths_test.go`, `viper_test.go`) to consistently isolate environment variables and directories, preventing test interference and ensuring reliable results
- Source fetcher initialization - Modified `FetchSourcesWithCleanup` in `git/sources.go` to pass the config file path to the source fetcher for correct local path resolution

**Removed:**

- Restriction to only git sources - Lifted the limitation that only git sources are supported, enabling broader external asset integration through local directories