### PR TITLE
build: update go version to 1.26.3 in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cowdogmoo/warpgate/v3
 
-go 1.26.2
+go 1.26.3
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.21.1


### PR DESCRIPTION
**Key Changes:**

- Bumped Go toolchain from 1.26.2 to 1.26.3 to pull in stdlib security fixes
- Resolves four govulncheck-reported vulnerabilities currently blocking pre-commit CI on every PR (e.g. #1840)
- Verified locally with `govulncheck ./...` against go1.26.3: no vulnerabilities found

**Changed:**

- `go` directive in `go.mod` updated from 1.26.2 to 1.26.3; CI uses `go-version-file: go.mod`, so `actions/setup-go` will install 1.26.3 on next run with no workflow changes required

**Fixed:**

- GO-2026-4982 — XSS in `html/template` (meta content URL escaping bypass), fixed in go1.26.3
- GO-2026-4980 — XSS in `html/template` (escaper bypass), fixed in go1.26.3
- GO-2026-4971 — Panic in `net.Dial`/`LookupPort` on Windows for NUL bytes, fixed in go1.26.3
- GO-2026-4918 — Infinite loop in HTTP/2 transport on bad `SETTINGS_MAX_FRAME_SIZE` (`net/http`), fixed in go1.26.3