### PR TITLE
feat: enable real ssh provisioning for proxmox builds

### DIFF
--- a/builder/proxmox/runner.go
+++ b/builder/proxmox/runner.go
@@ -220,36 +220,9 @@ func pickAgentIP(ifaces []*pveapi.AgentNetworkIface) (string, error) {
 	return "", fmt.Errorf("no non-loopback IPv4 address reported by guest agent")
 }
 
-// defaultSSHRunnerFactory builds the default SSHRunner implementation.
-// Currently returns a stub runner that records commands without contacting
-// the host. The real ssh.Client wiring lives in a follow-up; this keeps
-// the package compilable and useful for integration scaffolding.
-func defaultSSHRunnerFactory(_ context.Context, host string, target *builder.Target) (SSHRunner, error) {
-	return &stubSSHRunner{host: host, user: target.SSHUsername}, nil
+// defaultSSHRunnerFactory builds the production SSHRunner that talks to
+// the cloned VM over an actual SSH connection.
+func defaultSSHRunnerFactory(ctx context.Context, host string, target *builder.Target) (SSHRunner, error) {
+	conn := resolveSSHConnection(host, target)
+	return newSSHRunner(ctx, conn, defaultSSHDialDeadline, nil)
 }
-
-// stubSSHRunner is a placeholder SSHRunner that logs the commands it would
-// run. A real implementation backed by golang.org/x/crypto/ssh will replace
-// this in a follow-up; until then it lets the pipeline be wired end-to-end
-// without crashing when no provisioners are present.
-type stubSSHRunner struct {
-	host string
-	user string
-}
-
-// Run records the command but does not actually execute it. Returns an
-// error so misconfigured templates fail loudly rather than silently
-// reporting success.
-func (s *stubSSHRunner) Run(ctx context.Context, command string, env map[string]string) (string, error) {
-	logging.InfoContext(ctx, "[stub-ssh %s@%s] would run: %s (env=%d)", s.user, s.host, command, len(env))
-	return "", fmt.Errorf("SSH provisioning is not yet wired up; configure target.ssh and template.provisioners stub will run real commands once builder/proxmox/ssh.go lands")
-}
-
-// UploadFile records the upload but does not actually transfer the file.
-func (s *stubSSHRunner) UploadFile(ctx context.Context, source, destination, mode string) error {
-	logging.InfoContext(ctx, "[stub-ssh %s@%s] would upload: %s → %s (mode %s)", s.user, s.host, source, destination, mode)
-	return fmt.Errorf("SSH file upload is not yet wired up")
-}
-
-// Close is a no-op for the stub.
-func (s *stubSSHRunner) Close() error { return nil }

--- a/builder/proxmox/runner_test.go
+++ b/builder/proxmox/runner_test.go
@@ -33,31 +33,31 @@ import (
 	"github.com/cowdogmoo/warpgate/v3/builder"
 )
 
-func TestDefaultSSHRunnerFactory(t *testing.T) {
+func TestDefaultSSHRunnerFactory_RequiresAuth(t *testing.T) {
 	t.Parallel()
-	r, err := defaultSSHRunnerFactory(context.Background(), "10.0.0.1", &builder.Target{SSHUsername: "ansible"})
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
+	// No private key and no password — the factory must fail before any
+	// network I/O so misconfigured templates surface immediately.
+	_, err := defaultSSHRunnerFactory(context.Background(), "10.0.0.1", &builder.Target{SSHUsername: "ansible"})
+	if err == nil {
+		t.Fatal("expected error when no auth is configured")
 	}
-	if r == nil {
-		t.Fatal("expected non-nil runner")
-	}
-	if err := r.Close(); err != nil {
-		t.Fatalf("close failed: %v", err)
+	if !strings.Contains(err.Error(), "private key or password") {
+		t.Fatalf("expected auth-required error, got %v", err)
 	}
 }
 
-func TestStubSSHRunner_AlwaysFails(t *testing.T) {
+func TestDefaultSSHRunnerFactory_FallsBackToCloudInitUser(t *testing.T) {
 	t.Parallel()
-	r := &stubSSHRunner{host: "h", user: "u"}
-	if _, err := r.Run(context.Background(), "echo hi", nil); err == nil {
-		t.Fatal("expected Run to return error")
+	// When SSHUsername is unset, the runner should fall back to
+	// CloudInitUser. The factory will fail at auth (no key/password) but
+	// the user check fires first, so we assert the auth error rather than
+	// a missing-user error.
+	_, err := defaultSSHRunnerFactory(context.Background(), "10.0.0.1", &builder.Target{CloudInitUser: "kali"})
+	if err == nil {
+		t.Fatal("expected auth error")
 	}
-	if err := r.UploadFile(context.Background(), "src", "dst", "0644"); err == nil {
-		t.Fatal("expected UploadFile to return error")
-	}
-	if err := r.Close(); err != nil {
-		t.Fatalf("Close should be no-op nil, got %v", err)
+	if strings.Contains(err.Error(), "user is required") {
+		t.Fatalf("expected user fallback to CloudInitUser, got %v", err)
 	}
 }
 

--- a/builder/proxmox/ssh.go
+++ b/builder/proxmox/ssh.go
@@ -46,13 +46,22 @@ const (
 	sshConnectTimeout      = 15 * time.Second
 )
 
-// sshRunner is the production SSHRunner implementation backed by
-// golang.org/x/crypto/ssh. It opens a single client connection per build
-// and reuses it across provisioner steps, opening a fresh session per call.
+// runCmdFunc executes command on the remote host, optionally piping stdin
+// in and stdout/stderr out. It is the single seam between the testable
+// SSHRunner logic and the live golang.org/x/crypto/ssh plumbing. Tests
+// inject a fake runCmdFunc; production wires sshRunCmd around an ssh.Client.
+type runCmdFunc func(ctx context.Context, command string, stdin io.Reader, stdout, stderr io.Writer) error
+
+// sshRunner is the production SSHRunner. The interesting logic — env
+// exports, quoting, the upload-as-cat trick, chmod, error wrapping —
+// lives here and is exercised against a fake runCmd. The actual SSH
+// session work lives in sshRunCmd and is verified end-to-end by
+// runner_live_test.go against a real cluster.
 type sshRunner struct {
-	client *ssh.Client
 	addr   string
 	user   string
+	runCmd runCmdFunc
+	closer io.Closer
 }
 
 // dialSSHFunc is the indirection used to inject a fake dialer in tests.
@@ -83,7 +92,12 @@ func newSSHRunner(ctx context.Context, conn SSHConnection, dialDeadline time.Dur
 	for {
 		client, err := dial(ctx, "tcp", addr, cfg)
 		if err == nil {
-			return &sshRunner{client: client, addr: addr, user: conn.User}, nil
+			return &sshRunner{
+				addr:   addr,
+				user:   conn.User,
+				runCmd: sshRunCmd(client),
+				closer: client,
+			}, nil
 		}
 		lastErr = err
 		if ctx.Err() != nil {
@@ -149,31 +163,103 @@ func buildSSHClientConfig(conn SSHConnection) (*ssh.ClientConfig, error) {
 	}, nil
 }
 
-// Run opens a session, prefixes env exports, and executes command. Combined
-// stdout+stderr is returned so callers can log it on failure.
+// Run executes command on the remote host with env exported into the shell
+// before evaluation. Combined stdout+stderr is returned so callers can log
+// it on failure.
 func (s *sshRunner) Run(ctx context.Context, command string, env map[string]string) (string, error) {
-	sess, err := s.client.NewSession()
-	if err != nil {
-		return "", fmt.Errorf("open ssh session: %w", err)
-	}
-	defer func() { _ = sess.Close() }()
-
 	full := withEnvExports(env) + command
 	var out bytes.Buffer
-	sess.Stdout = &out
-	sess.Stderr = &out
+	if err := s.runCmd(ctx, full, nil, &out, &out); err != nil {
+		return out.String(), fmt.Errorf("run %q: %w", command, err)
+	}
+	return out.String(), nil
+}
 
-	done := make(chan error, 1)
-	go func() { done <- sess.Run(full) }()
-	select {
-	case err := <-done:
-		if err != nil {
-			return out.String(), fmt.Errorf("run %q: %w", command, err)
+// UploadFile copies source to destination by piping the file body to a
+// remote `cat > destination`. Mode is applied with chmod afterwards. Using
+// cat-over-stdin avoids pulling in an SCP/SFTP dep.
+func (s *sshRunner) UploadFile(ctx context.Context, source, destination, mode string) error {
+	f, err := os.Open(source)
+	if err != nil {
+		return fmt.Errorf("open source %s: %w", source, err)
+	}
+	defer func() { _ = f.Close() }()
+
+	var errBuf bytes.Buffer
+	cmd := fmt.Sprintf("cat > %s", shellQuote(destination))
+	if err := s.runCmd(ctx, cmd, f, io.Discard, &errBuf); err != nil {
+		stderr := strings.TrimSpace(errBuf.String())
+		if stderr != "" {
+			return fmt.Errorf("upload %s -> %s: %w (%s)", source, destination, err, stderr)
 		}
-		return out.String(), nil
-	case <-ctx.Done():
-		_ = sess.Signal(ssh.SIGKILL)
-		return out.String(), ctx.Err()
+		return fmt.Errorf("upload %s -> %s: %w", source, destination, err)
+	}
+
+	if mode != "" {
+		chmod := fmt.Sprintf("chmod %s %s", shellQuote(mode), shellQuote(destination))
+		if _, err := s.Run(ctx, chmod, nil); err != nil {
+			return fmt.Errorf("chmod %s %s: %w", mode, destination, err)
+		}
+	}
+	return nil
+}
+
+// Close shuts down the underlying ssh client connection.
+func (s *sshRunner) Close() error {
+	if s.closer == nil {
+		return nil
+	}
+	return s.closer.Close()
+}
+
+// sshRunCmd returns a runCmdFunc that executes the command in a fresh
+// ssh.Session on client. ctx cancellation sends SIGKILL to the remote
+// process. stdin is copied in a goroutine and signalled with channel-eof
+// when the source is exhausted.
+func sshRunCmd(client *ssh.Client) runCmdFunc {
+	return func(ctx context.Context, command string, stdin io.Reader, stdout, stderr io.Writer) error {
+		sess, err := client.NewSession()
+		if err != nil {
+			return fmt.Errorf("open ssh session: %w", err)
+		}
+		defer func() { _ = sess.Close() }()
+
+		sess.Stdout = stdout
+		sess.Stderr = stderr
+
+		var copyErr chan error
+		if stdin != nil {
+			pipe, err := sess.StdinPipe()
+			if err != nil {
+				return fmt.Errorf("open stdin pipe: %w", err)
+			}
+			copyErr = make(chan error, 1)
+			go func() {
+				_, err := io.Copy(pipe, stdin)
+				_ = pipe.Close()
+				copyErr <- err
+			}()
+		}
+
+		if err := sess.Start(command); err != nil {
+			return fmt.Errorf("start: %w", err)
+		}
+
+		done := make(chan error, 1)
+		go func() { done <- sess.Wait() }()
+
+		select {
+		case err := <-done:
+			if copyErr != nil {
+				if cerr := <-copyErr; cerr != nil {
+					return cerr
+				}
+			}
+			return err
+		case <-ctx.Done():
+			_ = sess.Signal(ssh.SIGKILL)
+			return ctx.Err()
+		}
 	}
 }
 
@@ -216,78 +302,6 @@ func sortStrings(s []string) {
 			s[j-1], s[j] = s[j], s[j-1]
 		}
 	}
-}
-
-// UploadFile copies source to destination via an ssh session that runs
-// `cat > destination`, then applies mode with chmod. We use cat-over-stdin
-// rather than SCP/SFTP so the package needs no extra deps.
-func (s *sshRunner) UploadFile(ctx context.Context, source, destination, mode string) error {
-	f, err := os.Open(source)
-	if err != nil {
-		return fmt.Errorf("open source %s: %w", source, err)
-	}
-	defer func() { _ = f.Close() }()
-
-	sess, err := s.client.NewSession()
-	if err != nil {
-		return fmt.Errorf("open ssh session for upload: %w", err)
-	}
-	defer func() { _ = sess.Close() }()
-
-	stdin, err := sess.StdinPipe()
-	if err != nil {
-		return fmt.Errorf("open stdin pipe: %w", err)
-	}
-
-	var errBuf bytes.Buffer
-	sess.Stderr = &errBuf
-
-	cmd := fmt.Sprintf("cat > %s", shellQuote(destination))
-	if err := sess.Start(cmd); err != nil {
-		return fmt.Errorf("start upload: %w", err)
-	}
-
-	copyDone := make(chan error, 1)
-	go func() {
-		_, copyErr := io.Copy(stdin, f)
-		_ = stdin.Close()
-		copyDone <- copyErr
-	}()
-
-	select {
-	case err := <-copyDone:
-		if err != nil {
-			_ = sess.Signal(ssh.SIGKILL)
-			return fmt.Errorf("write upload body: %w", err)
-		}
-	case <-ctx.Done():
-		_ = sess.Signal(ssh.SIGKILL)
-		return ctx.Err()
-	}
-
-	if err := sess.Wait(); err != nil {
-		stderr := strings.TrimSpace(errBuf.String())
-		if stderr != "" {
-			return fmt.Errorf("upload %s -> %s: %w (%s)", source, destination, err, stderr)
-		}
-		return fmt.Errorf("upload %s -> %s: %w", source, destination, err)
-	}
-
-	if mode != "" {
-		chmod := fmt.Sprintf("chmod %s %s", shellQuote(mode), shellQuote(destination))
-		if _, err := s.Run(ctx, chmod, nil); err != nil {
-			return fmt.Errorf("chmod %s %s: %w", mode, destination, err)
-		}
-	}
-	return nil
-}
-
-// Close shuts down the underlying ssh client connection.
-func (s *sshRunner) Close() error {
-	if s.client == nil {
-		return nil
-	}
-	return s.client.Close()
 }
 
 // resolveSSHConnection builds an SSHConnection from target. SSHUsername

--- a/builder/proxmox/ssh.go
+++ b/builder/proxmox/ssh.go
@@ -212,54 +212,72 @@ func (s *sshRunner) Close() error {
 	return s.closer.Close()
 }
 
-// sshRunCmd returns a runCmdFunc that executes the command in a fresh
-// ssh.Session on client. ctx cancellation sends SIGKILL to the remote
-// process. stdin is copied in a goroutine and signalled with channel-eof
-// when the source is exhausted.
+// sshSession is the subset of *ssh.Session that orchestrateSession needs.
+// Pulling it behind an interface lets the orchestration be tested without a
+// live SSH connection.
+type sshSession interface {
+	StdinPipe() (io.WriteCloser, error)
+	Start(cmd string) error
+	Wait() error
+	Signal(sig ssh.Signal) error
+	Close() error
+}
+
+// sshRunCmd returns a runCmdFunc that opens a fresh ssh.Session on client,
+// wires stdout/stderr, and hands the rest off to orchestrateSession. Kept
+// intentionally tiny so the (untestable) NewSession plumbing is isolated
+// from the orchestration logic.
 func sshRunCmd(client *ssh.Client) runCmdFunc {
 	return func(ctx context.Context, command string, stdin io.Reader, stdout, stderr io.Writer) error {
 		sess, err := client.NewSession()
 		if err != nil {
 			return fmt.Errorf("open ssh session: %w", err)
 		}
-		defer func() { _ = sess.Close() }()
-
 		sess.Stdout = stdout
 		sess.Stderr = stderr
+		return orchestrateSession(ctx, sess, command, stdin)
+	}
+}
 
-		var copyErr chan error
-		if stdin != nil {
-			pipe, err := sess.StdinPipe()
-			if err != nil {
-				return fmt.Errorf("open stdin pipe: %w", err)
+// orchestrateSession starts command on sess, pipes stdin in when supplied,
+// waits for completion, and sends SIGKILL on ctx cancellation. stdout and
+// stderr must already be wired on sess before the call. The session is
+// closed before returning.
+func orchestrateSession(ctx context.Context, sess sshSession, command string, stdin io.Reader) error {
+	defer func() { _ = sess.Close() }()
+
+	var copyErr chan error
+	if stdin != nil {
+		pipe, err := sess.StdinPipe()
+		if err != nil {
+			return fmt.Errorf("open stdin pipe: %w", err)
+		}
+		copyErr = make(chan error, 1)
+		go func() {
+			_, err := io.Copy(pipe, stdin)
+			_ = pipe.Close()
+			copyErr <- err
+		}()
+	}
+
+	if err := sess.Start(command); err != nil {
+		return fmt.Errorf("start: %w", err)
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- sess.Wait() }()
+
+	select {
+	case err := <-done:
+		if copyErr != nil {
+			if cerr := <-copyErr; cerr != nil {
+				return cerr
 			}
-			copyErr = make(chan error, 1)
-			go func() {
-				_, err := io.Copy(pipe, stdin)
-				_ = pipe.Close()
-				copyErr <- err
-			}()
 		}
-
-		if err := sess.Start(command); err != nil {
-			return fmt.Errorf("start: %w", err)
-		}
-
-		done := make(chan error, 1)
-		go func() { done <- sess.Wait() }()
-
-		select {
-		case err := <-done:
-			if copyErr != nil {
-				if cerr := <-copyErr; cerr != nil {
-					return cerr
-				}
-			}
-			return err
-		case <-ctx.Done():
-			_ = sess.Signal(ssh.SIGKILL)
-			return ctx.Err()
-		}
+		return err
+	case <-ctx.Done():
+		_ = sess.Signal(ssh.SIGKILL)
+		return ctx.Err()
 	}
 }
 

--- a/builder/proxmox/ssh.go
+++ b/builder/proxmox/ssh.go
@@ -1,0 +1,308 @@
+/*
+Copyright © 2026 Jayson Grace <jayson.e.grace@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+package proxmox
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"golang.org/x/crypto/ssh"
+
+	"github.com/cowdogmoo/warpgate/v3/builder"
+	"github.com/cowdogmoo/warpgate/v3/logging"
+)
+
+const (
+	defaultSSHPort         = 22
+	defaultSSHDialDeadline = 5 * time.Minute
+	sshDialRetryInterval   = 5 * time.Second
+	sshConnectTimeout      = 15 * time.Second
+)
+
+// sshRunner is the production SSHRunner implementation backed by
+// golang.org/x/crypto/ssh. It opens a single client connection per build
+// and reuses it across provisioner steps, opening a fresh session per call.
+type sshRunner struct {
+	client *ssh.Client
+	addr   string
+	user   string
+}
+
+// dialSSHFunc is the indirection used to inject a fake dialer in tests.
+type dialSSHFunc func(ctx context.Context, network, addr string, cfg *ssh.ClientConfig) (*ssh.Client, error)
+
+// newSSHRunner dials addr with a bounded retry window. Newly cloned VMs
+// often need a handful of cloud-init cycles before sshd starts listening,
+// so we retry until dialDeadline elapses or ctx is cancelled.
+func newSSHRunner(ctx context.Context, conn SSHConnection, dialDeadline time.Duration, dial dialSSHFunc) (*sshRunner, error) {
+	cfg, err := buildSSHClientConfig(conn)
+	if err != nil {
+		return nil, err
+	}
+	port := conn.Port
+	if port == 0 {
+		port = defaultSSHPort
+	}
+	addr := net.JoinHostPort(conn.Host, strconv.Itoa(port))
+	if dial == nil {
+		dial = dialSSH
+	}
+	if dialDeadline <= 0 {
+		dialDeadline = defaultSSHDialDeadline
+	}
+
+	deadline := time.Now().Add(dialDeadline)
+	var lastErr error
+	for {
+		client, err := dial(ctx, "tcp", addr, cfg)
+		if err == nil {
+			return &sshRunner{client: client, addr: addr, user: conn.User}, nil
+		}
+		lastErr = err
+		if ctx.Err() != nil {
+			return nil, fmt.Errorf("dial %s: %w", addr, ctx.Err())
+		}
+		if time.Now().After(deadline) {
+			return nil, fmt.Errorf("dial %s after %s: %w", addr, dialDeadline, lastErr)
+		}
+		logging.DebugContext(ctx, "ssh dial %s not ready: %v; retrying in %s", addr, err, sshDialRetryInterval)
+		select {
+		case <-time.After(sshDialRetryInterval):
+		case <-ctx.Done():
+			return nil, fmt.Errorf("dial %s: %w", addr, ctx.Err())
+		}
+	}
+}
+
+// dialSSH wraps ssh.NewClient with a per-attempt TCP connect timeout so a
+// hung SYN doesn't extend the overall retry window.
+func dialSSH(ctx context.Context, network, addr string, cfg *ssh.ClientConfig) (*ssh.Client, error) {
+	d := net.Dialer{Timeout: sshConnectTimeout}
+	raw, err := d.DialContext(ctx, network, addr)
+	if err != nil {
+		return nil, err
+	}
+	c, chans, reqs, err := ssh.NewClientConn(raw, addr, cfg)
+	if err != nil {
+		_ = raw.Close()
+		return nil, err
+	}
+	return ssh.NewClient(c, chans, reqs), nil
+}
+
+// buildSSHClientConfig builds an ssh.ClientConfig from conn. Either
+// PrivateKey or Password (or both) must be set.
+func buildSSHClientConfig(conn SSHConnection) (*ssh.ClientConfig, error) {
+	if conn.User == "" {
+		return nil, fmt.Errorf("ssh: user is required")
+	}
+	var auth []ssh.AuthMethod
+	if conn.PrivateKey != "" {
+		signer, err := ssh.ParsePrivateKey([]byte(conn.PrivateKey))
+		if err != nil {
+			return nil, fmt.Errorf("parse private key: %w", err)
+		}
+		auth = append(auth, ssh.PublicKeys(signer))
+	}
+	if conn.Password != "" {
+		auth = append(auth, ssh.Password(conn.Password))
+	}
+	if len(auth) == 0 {
+		return nil, fmt.Errorf("ssh: either private key or password is required")
+	}
+	// Build VMs are ephemeral and freshly created by warpgate — there is
+	// no prior known_hosts entry to verify against. Pinning host keys
+	// here would require an out-of-band channel to fetch them from the
+	// source template, which warpgate doesn't have.
+	return &ssh.ClientConfig{
+		User:            conn.User,
+		Auth:            auth,
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+		Timeout:         sshConnectTimeout,
+	}, nil
+}
+
+// Run opens a session, prefixes env exports, and executes command. Combined
+// stdout+stderr is returned so callers can log it on failure.
+func (s *sshRunner) Run(ctx context.Context, command string, env map[string]string) (string, error) {
+	sess, err := s.client.NewSession()
+	if err != nil {
+		return "", fmt.Errorf("open ssh session: %w", err)
+	}
+	defer func() { _ = sess.Close() }()
+
+	full := withEnvExports(env) + command
+	var out bytes.Buffer
+	sess.Stdout = &out
+	sess.Stderr = &out
+
+	done := make(chan error, 1)
+	go func() { done <- sess.Run(full) }()
+	select {
+	case err := <-done:
+		if err != nil {
+			return out.String(), fmt.Errorf("run %q: %w", command, err)
+		}
+		return out.String(), nil
+	case <-ctx.Done():
+		_ = sess.Signal(ssh.SIGKILL)
+		return out.String(), ctx.Err()
+	}
+}
+
+// withEnvExports renders a `export K='V'; ...` prefix the remote sh
+// evaluates before command. Many sshd builds disable SendEnv/AcceptEnv, so
+// passing envs as exports is the only portable channel.
+func withEnvExports(env map[string]string) string {
+	if len(env) == 0 {
+		return ""
+	}
+	keys := make([]string, 0, len(env))
+	for k := range env {
+		keys = append(keys, k)
+	}
+	// Sort for deterministic output (tests, logs).
+	sortStrings(keys)
+
+	var b strings.Builder
+	for _, k := range keys {
+		b.WriteString("export ")
+		b.WriteString(k)
+		b.WriteString("=")
+		b.WriteString(shellQuote(env[k]))
+		b.WriteString("; ")
+	}
+	return b.String()
+}
+
+// shellQuote wraps s in single quotes, escaping any embedded single quotes
+// via the standard '\” trick. Safe for arbitrary bytes.
+func shellQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}
+
+// sortStrings is a tiny stand-in for sort.Strings so this file doesn't have
+// to import "sort" for a single call site.
+func sortStrings(s []string) {
+	for i := 1; i < len(s); i++ {
+		for j := i; j > 0 && s[j-1] > s[j]; j-- {
+			s[j-1], s[j] = s[j], s[j-1]
+		}
+	}
+}
+
+// UploadFile copies source to destination via an ssh session that runs
+// `cat > destination`, then applies mode with chmod. We use cat-over-stdin
+// rather than SCP/SFTP so the package needs no extra deps.
+func (s *sshRunner) UploadFile(ctx context.Context, source, destination, mode string) error {
+	f, err := os.Open(source)
+	if err != nil {
+		return fmt.Errorf("open source %s: %w", source, err)
+	}
+	defer func() { _ = f.Close() }()
+
+	sess, err := s.client.NewSession()
+	if err != nil {
+		return fmt.Errorf("open ssh session for upload: %w", err)
+	}
+	defer func() { _ = sess.Close() }()
+
+	stdin, err := sess.StdinPipe()
+	if err != nil {
+		return fmt.Errorf("open stdin pipe: %w", err)
+	}
+
+	var errBuf bytes.Buffer
+	sess.Stderr = &errBuf
+
+	cmd := fmt.Sprintf("cat > %s", shellQuote(destination))
+	if err := sess.Start(cmd); err != nil {
+		return fmt.Errorf("start upload: %w", err)
+	}
+
+	copyDone := make(chan error, 1)
+	go func() {
+		_, copyErr := io.Copy(stdin, f)
+		_ = stdin.Close()
+		copyDone <- copyErr
+	}()
+
+	select {
+	case err := <-copyDone:
+		if err != nil {
+			_ = sess.Signal(ssh.SIGKILL)
+			return fmt.Errorf("write upload body: %w", err)
+		}
+	case <-ctx.Done():
+		_ = sess.Signal(ssh.SIGKILL)
+		return ctx.Err()
+	}
+
+	if err := sess.Wait(); err != nil {
+		stderr := strings.TrimSpace(errBuf.String())
+		if stderr != "" {
+			return fmt.Errorf("upload %s -> %s: %w (%s)", source, destination, err, stderr)
+		}
+		return fmt.Errorf("upload %s -> %s: %w", source, destination, err)
+	}
+
+	if mode != "" {
+		chmod := fmt.Sprintf("chmod %s %s", shellQuote(mode), shellQuote(destination))
+		if _, err := s.Run(ctx, chmod, nil); err != nil {
+			return fmt.Errorf("chmod %s %s: %w", mode, destination, err)
+		}
+	}
+	return nil
+}
+
+// Close shuts down the underlying ssh client connection.
+func (s *sshRunner) Close() error {
+	if s.client == nil {
+		return nil
+	}
+	return s.client.Close()
+}
+
+// resolveSSHConnection builds an SSHConnection from target. SSHUsername
+// falls back to CloudInitUser when unset, so callers that wire cloud-init
+// once get matching SSH access without repeating themselves.
+func resolveSSHConnection(host string, target *builder.Target) SSHConnection {
+	conn := SSHConnection{
+		Host:       host,
+		Port:       target.SSHPort,
+		User:       target.SSHUsername,
+		Password:   target.SSHPassword,
+		PrivateKey: target.SSHPrivateKey,
+	}
+	if conn.User == "" {
+		conn.User = target.CloudInitUser
+	}
+	return conn
+}

--- a/builder/proxmox/ssh_test.go
+++ b/builder/proxmox/ssh_test.go
@@ -1,0 +1,266 @@
+/*
+Copyright © 2026 Jayson Grace <jayson.e.grace@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+package proxmox
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/pem"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"golang.org/x/crypto/ssh"
+
+	"github.com/cowdogmoo/warpgate/v3/builder"
+)
+
+// generateTestPrivateKeyPEM returns a freshly-generated ed25519 private key
+// in OpenSSH PEM form. Used by tests that need a valid key the ssh package
+// will accept.
+func generateTestPrivateKeyPEM(t *testing.T) string {
+	t.Helper()
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate ed25519 key: %v", err)
+	}
+	block, err := ssh.MarshalPrivateKey(priv, "warpgate-test")
+	if err != nil {
+		t.Fatalf("marshal private key: %v", err)
+	}
+	return string(pem.EncodeToMemory(block))
+}
+
+func TestBuildSSHClientConfig_RequiresUser(t *testing.T) {
+	t.Parallel()
+	_, err := buildSSHClientConfig(SSHConnection{Password: "pw"})
+	if err == nil || !strings.Contains(err.Error(), "user is required") {
+		t.Fatalf("expected user-required error, got %v", err)
+	}
+}
+
+func TestBuildSSHClientConfig_RequiresAuth(t *testing.T) {
+	t.Parallel()
+	_, err := buildSSHClientConfig(SSHConnection{User: "root"})
+	if err == nil || !strings.Contains(err.Error(), "private key or password") {
+		t.Fatalf("expected auth-required error, got %v", err)
+	}
+}
+
+func TestBuildSSHClientConfig_PasswordOnly(t *testing.T) {
+	t.Parallel()
+	cfg, err := buildSSHClientConfig(SSHConnection{User: "root", Password: "secret"})
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if cfg.User != "root" {
+		t.Fatalf("user = %q, want %q", cfg.User, "root")
+	}
+	if len(cfg.Auth) != 1 {
+		t.Fatalf("expected 1 auth method, got %d", len(cfg.Auth))
+	}
+}
+
+func TestBuildSSHClientConfig_PrivateKeyInvalid(t *testing.T) {
+	t.Parallel()
+	_, err := buildSSHClientConfig(SSHConnection{User: "root", PrivateKey: "not a key"})
+	if err == nil || !strings.Contains(err.Error(), "parse private key") {
+		t.Fatalf("expected parse error, got %v", err)
+	}
+}
+
+func TestBuildSSHClientConfig_PrivateKeyValid(t *testing.T) {
+	t.Parallel()
+	key := generateTestPrivateKeyPEM(t)
+	cfg, err := buildSSHClientConfig(SSHConnection{User: "root", PrivateKey: key})
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if len(cfg.Auth) != 1 {
+		t.Fatalf("expected 1 auth method, got %d", len(cfg.Auth))
+	}
+}
+
+func TestShellQuote(t *testing.T) {
+	t.Parallel()
+	cases := map[string]string{
+		"":                    "''",
+		"plain":               "'plain'",
+		"with space":          "'with space'",
+		"with'quote":          `'with'\''quote'`,
+		"multi 'quotes' here": `'multi '\''quotes'\'' here'`,
+	}
+	for in, want := range cases {
+		if got := shellQuote(in); got != want {
+			t.Errorf("shellQuote(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestWithEnvExports_EmptyReturnsEmpty(t *testing.T) {
+	t.Parallel()
+	if got := withEnvExports(nil); got != "" {
+		t.Fatalf("expected empty for nil env, got %q", got)
+	}
+	if got := withEnvExports(map[string]string{}); got != "" {
+		t.Fatalf("expected empty for empty env, got %q", got)
+	}
+}
+
+func TestWithEnvExports_SortedAndQuoted(t *testing.T) {
+	t.Parallel()
+	got := withEnvExports(map[string]string{
+		"BAR": "hello world",
+		"AAA": "v",
+		"FOO": "it's me",
+	})
+	want := `export AAA='v'; export BAR='hello world'; export FOO='it'\''s me'; `
+	if got != want {
+		t.Fatalf("withEnvExports mismatch:\ngot:  %q\nwant: %q", got, want)
+	}
+}
+
+func TestResolveSSHConnection_FallsBackToCloudInitUser(t *testing.T) {
+	t.Parallel()
+	conn := resolveSSHConnection("10.0.0.5", &builder.Target{
+		CloudInitUser: "kali",
+		SSHPort:       2222,
+		SSHPrivateKey: "key",
+		SSHPassword:   "pw",
+	})
+	if conn.User != "kali" {
+		t.Fatalf("user = %q, want %q", conn.User, "kali")
+	}
+	if conn.Port != 2222 {
+		t.Fatalf("port = %d, want 2222", conn.Port)
+	}
+	if conn.PrivateKey != "key" || conn.Password != "pw" {
+		t.Fatalf("auth fields not propagated: %+v", conn)
+	}
+}
+
+func TestResolveSSHConnection_PrefersExplicitUser(t *testing.T) {
+	t.Parallel()
+	conn := resolveSSHConnection("10.0.0.5", &builder.Target{
+		CloudInitUser: "kali",
+		SSHUsername:   "deploy",
+		SSHPrivateKey: "k",
+	})
+	if conn.User != "deploy" {
+		t.Fatalf("user = %q, want %q", conn.User, "deploy")
+	}
+}
+
+func TestNewSSHRunner_DialErrorPropagates(t *testing.T) {
+	t.Parallel()
+	dial := func(context.Context, string, string, *ssh.ClientConfig) (*ssh.Client, error) {
+		return nil, errors.New("connection refused")
+	}
+	_, err := newSSHRunner(
+		context.Background(),
+		SSHConnection{Host: "h", Port: 22, User: "root", Password: "pw"},
+		50*time.Millisecond,
+		dial,
+	)
+	if err == nil {
+		t.Fatal("expected dial error after deadline")
+	}
+	if !strings.Contains(err.Error(), "connection refused") {
+		t.Fatalf("expected wrapped connection refused, got %v", err)
+	}
+}
+
+func TestNewSSHRunner_RetriesUntilSuccess(t *testing.T) {
+	t.Parallel()
+	calls := 0
+	dial := func(context.Context, string, string, *ssh.ClientConfig) (*ssh.Client, error) {
+		calls++
+		if calls < 2 {
+			return nil, errors.New("not ready")
+		}
+		// Return a non-nil client we never use. nil works for the test
+		// since we only check it's returned, not exercised.
+		return &ssh.Client{}, nil
+	}
+	// Bump the retry interval down via a much shorter deadline window;
+	// the test uses the default 5s retry which would be too slow, so we
+	// give the deadline enough room for one tick.
+	r, err := newSSHRunner(
+		context.Background(),
+		SSHConnection{Host: "h", Port: 22, User: "root", Password: "pw"},
+		10*time.Second,
+		dial,
+	)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if r == nil {
+		t.Fatal("expected runner")
+	}
+	if calls < 2 {
+		t.Fatalf("expected at least 2 dial attempts, got %d", calls)
+	}
+}
+
+func TestNewSSHRunner_ContextCancellationStops(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	dial := func(context.Context, string, string, *ssh.ClientConfig) (*ssh.Client, error) {
+		return nil, errors.New("not ready")
+	}
+	_, err := newSSHRunner(
+		ctx,
+		SSHConnection{Host: "h", Port: 22, User: "root", Password: "pw"},
+		time.Hour,
+		dial,
+	)
+	if err == nil {
+		t.Fatal("expected ctx cancel error")
+	}
+	if !strings.Contains(err.Error(), "context") {
+		t.Fatalf("expected context error, got %v", err)
+	}
+}
+
+func TestSortStringsInPlace(t *testing.T) {
+	t.Parallel()
+	s := []string{"c", "a", "b", "a"}
+	sortStrings(s)
+	want := []string{"a", "a", "b", "c"}
+	for i := range want {
+		if s[i] != want[i] {
+			t.Fatalf("sortStrings: got %v, want %v", s, want)
+		}
+	}
+}
+
+func TestSSHRunner_CloseNilClient(t *testing.T) {
+	t.Parallel()
+	r := &sshRunner{}
+	if err := r.Close(); err != nil {
+		t.Fatalf("Close on nil client should be no-op, got %v", err)
+	}
+}

--- a/builder/proxmox/ssh_test.go
+++ b/builder/proxmox/ssh_test.go
@@ -517,6 +517,177 @@ func TestDialSSH_ConnectionRefusedFails(t *testing.T) {
 	}
 }
 
+// fakeSession is a stand-in for *ssh.Session that lets us drive
+// orchestrateSession's branches without a live SSH connection.
+type fakeSession struct {
+	stdinPipeErr error
+	startErr     error
+	waitErr      error
+	waitDelay    time.Duration
+	startCalled  string
+	signaled     ssh.Signal
+	closed       bool
+	pipeWritten  []byte
+	pipeCloseErr error
+}
+
+type fakePipe struct {
+	parent *fakeSession
+	buf    bytes.Buffer
+}
+
+func (p *fakePipe) Write(b []byte) (int, error) { return p.buf.Write(b) }
+func (p *fakePipe) Close() error {
+	p.parent.pipeWritten = p.buf.Bytes()
+	return p.parent.pipeCloseErr
+}
+
+func (s *fakeSession) StdinPipe() (io.WriteCloser, error) {
+	if s.stdinPipeErr != nil {
+		return nil, s.stdinPipeErr
+	}
+	return &fakePipe{parent: s}, nil
+}
+
+func (s *fakeSession) Start(cmd string) error {
+	s.startCalled = cmd
+	return s.startErr
+}
+
+func (s *fakeSession) Wait() error {
+	if s.waitDelay > 0 {
+		time.Sleep(s.waitDelay)
+	}
+	return s.waitErr
+}
+
+func (s *fakeSession) Signal(sig ssh.Signal) error { s.signaled = sig; return nil }
+func (s *fakeSession) Close() error                { s.closed = true; return nil }
+
+func TestOrchestrateSession_StartErrorWraps(t *testing.T) {
+	t.Parallel()
+	sess := &fakeSession{startErr: errors.New("boom")}
+	err := orchestrateSession(context.Background(), sess, "cmd", nil)
+	if err == nil || !strings.Contains(err.Error(), "start:") {
+		t.Fatalf("expected wrapped start error, got %v", err)
+	}
+	if !sess.closed {
+		t.Fatal("expected session to be closed on error path")
+	}
+}
+
+func TestOrchestrateSession_HappyPathReturnsWaitNil(t *testing.T) {
+	t.Parallel()
+	sess := &fakeSession{}
+	if err := orchestrateSession(context.Background(), sess, "cmd", nil); err != nil {
+		t.Fatalf("orchestrateSession: %v", err)
+	}
+	if sess.startCalled != "cmd" {
+		t.Fatalf("Start called with %q, want %q", sess.startCalled, "cmd")
+	}
+	if !sess.closed {
+		t.Fatal("expected session to be closed")
+	}
+}
+
+func TestOrchestrateSession_WaitErrorPropagates(t *testing.T) {
+	t.Parallel()
+	sess := &fakeSession{waitErr: errors.New("exit 1")}
+	err := orchestrateSession(context.Background(), sess, "cmd", nil)
+	if err == nil || err.Error() != "exit 1" {
+		t.Fatalf("expected raw wait error, got %v", err)
+	}
+}
+
+func TestOrchestrateSession_StdinPipedToSession(t *testing.T) {
+	t.Parallel()
+	sess := &fakeSession{}
+	body := strings.NewReader("payload-bytes")
+	if err := orchestrateSession(context.Background(), sess, "cat > /dst", body); err != nil {
+		t.Fatalf("orchestrateSession: %v", err)
+	}
+	if string(sess.pipeWritten) != "payload-bytes" {
+		t.Fatalf("pipe got %q, want %q", sess.pipeWritten, "payload-bytes")
+	}
+}
+
+func TestOrchestrateSession_StdinPipeErrorWraps(t *testing.T) {
+	t.Parallel()
+	sess := &fakeSession{stdinPipeErr: errors.New("ENOMEM")}
+	err := orchestrateSession(context.Background(), sess, "cat > /dst", strings.NewReader("x"))
+	if err == nil || !strings.Contains(err.Error(), "open stdin pipe") {
+		t.Fatalf("expected stdin pipe error, got %v", err)
+	}
+}
+
+// erroringReader fails on every Read so io.Copy in the stdin goroutine
+// returns a non-nil error.
+type erroringReader struct{ err error }
+
+func (e erroringReader) Read([]byte) (int, error) { return 0, e.err }
+
+func TestOrchestrateSession_CopyErrorBeatsWaitNil(t *testing.T) {
+	t.Parallel()
+	sess := &fakeSession{}
+	err := orchestrateSession(context.Background(), sess, "cat > /dst", erroringReader{err: errors.New("read fail")})
+	if err == nil || !strings.Contains(err.Error(), "read fail") {
+		t.Fatalf("expected copy error to surface, got %v", err)
+	}
+}
+
+func TestOrchestrateSession_ContextCancelSendsSIGKILL(t *testing.T) {
+	t.Parallel()
+	sess := &fakeSession{waitDelay: 200 * time.Millisecond, waitErr: errors.New("wait")}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	err := orchestrateSession(ctx, sess, "cmd", nil)
+	if err == nil || !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected ctx.Canceled, got %v", err)
+	}
+	if sess.signaled != ssh.SIGKILL {
+		t.Fatalf("expected SIGKILL on cancel, got %q", sess.signaled)
+	}
+}
+
+// stubDial just hands back a *ssh.Client we ignore — used to drive
+// newSSHRunner happy and ctx-during-retry paths without real I/O.
+func stubDialSuccess(_ context.Context, _, _ string, _ *ssh.ClientConfig) (*ssh.Client, error) {
+	return &ssh.Client{}, nil
+}
+
+func TestNewSSHRunner_SuccessFirstAttemptReturnsRunner(t *testing.T) {
+	t.Parallel()
+	r, err := newSSHRunner(context.Background(), SSHConnection{
+		Host: "h", User: "u", Password: "pw",
+	}, time.Second, stubDialSuccess)
+	if err != nil {
+		t.Fatalf("newSSHRunner: %v", err)
+	}
+	if r == nil || r.runCmd == nil || r.closer == nil {
+		t.Fatal("expected fully populated runner")
+	}
+}
+
+func TestNewSSHRunner_CtxCancelledMidRetryReturns(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithCancel(context.Background())
+	calls := 0
+	dial := func(context.Context, string, string, *ssh.ClientConfig) (*ssh.Client, error) {
+		calls++
+		// First call fails so we enter the retry select; cancel ctx so
+		// the select's ctx.Done branch fires.
+		go cancel()
+		return nil, errors.New("not ready")
+	}
+	_, err := newSSHRunner(ctx, SSHConnection{Host: "h", User: "u", Password: "pw"}, time.Hour, dial)
+	if err == nil || !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected ctx.Canceled, got %v", err)
+	}
+	if calls == 0 {
+		t.Fatal("expected at least one dial attempt")
+	}
+}
+
 func TestDialSSH_NonSSHListenerFailsHandshake(t *testing.T) {
 	t.Parallel()
 	ln, err := net.Listen("tcp", "127.0.0.1:0")

--- a/builder/proxmox/ssh_test.go
+++ b/builder/proxmox/ssh_test.go
@@ -23,11 +23,16 @@ THE SOFTWARE.
 package proxmox
 
 import (
+	"bytes"
 	"context"
 	"crypto/ed25519"
 	"crypto/rand"
 	"encoding/pem"
 	"errors"
+	"io"
+	"net"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -257,10 +262,286 @@ func TestSortStringsInPlace(t *testing.T) {
 	}
 }
 
-func TestSSHRunner_CloseNilClient(t *testing.T) {
+func TestSSHRunner_CloseNilCloser(t *testing.T) {
 	t.Parallel()
 	r := &sshRunner{}
 	if err := r.Close(); err != nil {
-		t.Fatalf("Close on nil client should be no-op, got %v", err)
+		t.Fatalf("Close with nil closer should be no-op, got %v", err)
+	}
+}
+
+// fakeCloser captures Close calls so we can assert sshRunner.Close
+// delegates to the underlying ssh client.
+type fakeCloser struct {
+	closed bool
+	err    error
+}
+
+func (f *fakeCloser) Close() error {
+	f.closed = true
+	return f.err
+}
+
+func TestSSHRunner_CloseDelegates(t *testing.T) {
+	t.Parallel()
+	fc := &fakeCloser{}
+	r := &sshRunner{closer: fc}
+	if err := r.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if !fc.closed {
+		t.Fatal("expected closer to be invoked")
+	}
+}
+
+// fakeCmd captures one invocation of a runCmdFunc so tests can assert on
+// the command line, stdin payload, and emitted stdout/stderr.
+type fakeCmd struct {
+	command  string
+	stdinBuf []byte
+	stdout   string
+	stderr   string
+	err      error
+}
+
+func (f *fakeCmd) run(_ context.Context, command string, stdin io.Reader, stdout, stderr io.Writer) error {
+	f.command = command
+	if stdin != nil {
+		var b bytes.Buffer
+		if _, err := io.Copy(&b, stdin); err != nil {
+			return err
+		}
+		f.stdinBuf = b.Bytes()
+	}
+	if f.stdout != "" {
+		_, _ = stdout.Write([]byte(f.stdout))
+	}
+	if f.stderr != "" {
+		_, _ = stderr.Write([]byte(f.stderr))
+	}
+	return f.err
+}
+
+// chainCmd wires up a sequence of fakeCmd responses so tests can model
+// multi-step calls like UploadFile (cat then chmod).
+type chainCmd struct {
+	calls []*fakeCmd
+	idx   int
+}
+
+func (c *chainCmd) run(ctx context.Context, command string, stdin io.Reader, stdout, stderr io.Writer) error {
+	if c.idx >= len(c.calls) {
+		return errors.New("chainCmd: no more scripted responses")
+	}
+	fc := c.calls[c.idx]
+	c.idx++
+	return fc.run(ctx, command, stdin, stdout, stderr)
+}
+
+func TestSSHRunner_Run_HappyPathReturnsStdout(t *testing.T) {
+	t.Parallel()
+	fc := &fakeCmd{stdout: "hello\n"}
+	r := &sshRunner{runCmd: fc.run}
+	out, err := r.Run(context.Background(), "echo hello", nil)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if out != "hello\n" {
+		t.Fatalf("out = %q, want %q", out, "hello\n")
+	}
+	if fc.command != "echo hello" {
+		t.Fatalf("command = %q, want plain command (no env)", fc.command)
+	}
+}
+
+func TestSSHRunner_Run_EnvPrefixedToCommand(t *testing.T) {
+	t.Parallel()
+	fc := &fakeCmd{stdout: "ok"}
+	r := &sshRunner{runCmd: fc.run}
+	_, err := r.Run(context.Background(), "cmd", map[string]string{"BAR": "two", "AAA": "one"})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	want := "export AAA='one'; export BAR='two'; cmd"
+	if fc.command != want {
+		t.Fatalf("command = %q, want %q", fc.command, want)
+	}
+}
+
+func TestSSHRunner_Run_WrapsErrorWithCommand(t *testing.T) {
+	t.Parallel()
+	fc := &fakeCmd{stdout: "partial", err: errors.New("exit 1")}
+	r := &sshRunner{runCmd: fc.run}
+	out, err := r.Run(context.Background(), "fail.sh", nil)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), `run "fail.sh"`) {
+		t.Fatalf("expected wrapped command in error, got %v", err)
+	}
+	if out != "partial" {
+		t.Fatalf("partial output should still be returned, got %q", out)
+	}
+}
+
+func TestSSHRunner_UploadFile_StreamsAndChmod(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src.txt")
+	body := []byte("payload\n")
+	if err := os.WriteFile(src, body, 0o600); err != nil {
+		t.Fatalf("write src: %v", err)
+	}
+	chain := &chainCmd{calls: []*fakeCmd{{}, {}}}
+	r := &sshRunner{runCmd: chain.run}
+
+	if err := r.UploadFile(context.Background(), src, "/opt/dst", "0640"); err != nil {
+		t.Fatalf("UploadFile: %v", err)
+	}
+	if chain.idx != 2 {
+		t.Fatalf("expected 2 commands (cat + chmod), got %d", chain.idx)
+	}
+	if got := chain.calls[0].command; got != "cat > '/opt/dst'" {
+		t.Fatalf("first command = %q, want cat redirect", got)
+	}
+	if string(chain.calls[0].stdinBuf) != string(body) {
+		t.Fatalf("stdin = %q, want %q", chain.calls[0].stdinBuf, body)
+	}
+	if got := chain.calls[1].command; got != "chmod '0640' '/opt/dst'" {
+		t.Fatalf("second command = %q, want chmod", got)
+	}
+}
+
+func TestSSHRunner_UploadFile_NoModeSkipsChmod(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src.txt")
+	if err := os.WriteFile(src, []byte("x"), 0o600); err != nil {
+		t.Fatalf("write src: %v", err)
+	}
+	chain := &chainCmd{calls: []*fakeCmd{{}}}
+	r := &sshRunner{runCmd: chain.run}
+
+	if err := r.UploadFile(context.Background(), src, "/opt/dst", ""); err != nil {
+		t.Fatalf("UploadFile: %v", err)
+	}
+	if chain.idx != 1 {
+		t.Fatalf("expected exactly 1 command (no chmod), got %d", chain.idx)
+	}
+}
+
+func TestSSHRunner_UploadFile_MissingSourceWraps(t *testing.T) {
+	t.Parallel()
+	r := &sshRunner{runCmd: (&fakeCmd{}).run}
+	err := r.UploadFile(context.Background(), filepath.Join(t.TempDir(), "missing"), "/tmp/dst", "")
+	if err == nil {
+		t.Fatal("expected error opening missing source")
+	}
+	if !strings.Contains(err.Error(), "open source") {
+		t.Fatalf("expected open source error, got %v", err)
+	}
+}
+
+func TestSSHRunner_UploadFile_CatFailureIncludesStderr(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src.txt")
+	if err := os.WriteFile(src, []byte("x"), 0o600); err != nil {
+		t.Fatalf("write src: %v", err)
+	}
+	chain := &chainCmd{calls: []*fakeCmd{{
+		err:    errors.New("exit 1"),
+		stderr: "permission denied\n",
+	}}}
+	r := &sshRunner{runCmd: chain.run}
+	err := r.UploadFile(context.Background(), src, "/opt/dst", "0640")
+	if err == nil {
+		t.Fatal("expected upload failure")
+	}
+	if !strings.Contains(err.Error(), "permission denied") {
+		t.Fatalf("expected stderr in error, got %v", err)
+	}
+}
+
+func TestSSHRunner_UploadFile_CatFailureBareWithoutStderr(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src.txt")
+	if err := os.WriteFile(src, []byte("x"), 0o600); err != nil {
+		t.Fatalf("write src: %v", err)
+	}
+	chain := &chainCmd{calls: []*fakeCmd{{err: errors.New("eof")}}}
+	r := &sshRunner{runCmd: chain.run}
+	err := r.UploadFile(context.Background(), src, "/opt/dst", "0640")
+	if err == nil {
+		t.Fatal("expected upload failure")
+	}
+	if strings.Contains(err.Error(), "()") {
+		t.Fatalf("bare failure should not include empty parens, got %v", err)
+	}
+}
+
+func TestSSHRunner_UploadFile_ChmodFailureSurfaces(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src.txt")
+	if err := os.WriteFile(src, []byte("x"), 0o600); err != nil {
+		t.Fatalf("write src: %v", err)
+	}
+	chain := &chainCmd{calls: []*fakeCmd{
+		{},
+		{err: errors.New("operation not permitted")},
+	}}
+	r := &sshRunner{runCmd: chain.run}
+	err := r.UploadFile(context.Background(), src, "/opt/dst", "0640")
+	if err == nil {
+		t.Fatal("expected chmod error to surface")
+	}
+	if !strings.Contains(err.Error(), "chmod 0640 /opt/dst") {
+		t.Fatalf("expected chmod context in error, got %v", err)
+	}
+}
+
+func TestDialSSH_ConnectionRefusedFails(t *testing.T) {
+	t.Parallel()
+	cfg := &ssh.ClientConfig{
+		User:            "x",
+		Auth:            []ssh.AuthMethod{ssh.Password("y")},
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+		Timeout:         200 * time.Millisecond,
+	}
+	// 127.0.0.1:1 is privileged and reliably refuses on Linux/macOS test runners.
+	_, err := dialSSH(context.Background(), "tcp", "127.0.0.1:1", cfg)
+	if err == nil {
+		t.Fatal("expected dial failure to an unreachable port")
+	}
+}
+
+func TestDialSSH_NonSSHListenerFailsHandshake(t *testing.T) {
+	t.Parallel()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	t.Cleanup(func() { _ = ln.Close() })
+	// Accept and immediately close so the SSH handshake fails fast.
+	go func() {
+		for {
+			c, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			_ = c.Close()
+		}
+	}()
+	cfg := &ssh.ClientConfig{
+		User:            "x",
+		Auth:            []ssh.AuthMethod{ssh.Password("y")},
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+		Timeout:         500 * time.Millisecond,
+	}
+	_, err = dialSSH(context.Background(), "tcp", ln.Addr().String(), cfg)
+	if err == nil {
+		t.Fatal("expected ssh handshake failure against non-ssh listener")
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -167,7 +167,7 @@ require (
 	go.opentelemetry.io/proto/otlp v1.10.0 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	go.yaml.in/yaml/v4 v4.0.0-rc.4 // indirect
-	golang.org/x/crypto v0.52.0 // indirect
+	golang.org/x/crypto v0.52.0
 	golang.org/x/mod v0.36.0 // indirect
 	golang.org/x/net v0.55.0 // indirect
 	golang.org/x/text v0.37.0 // indirect


### PR DESCRIPTION
**Key Changes:**

- Replaced the Proxmox SSH provisioning stub with a production SSH runner that connects to cloned VMs and executes provisioner commands
- Added SSH authentication validation, retrying dial behavior, environment export handling, and file upload support
- Updated factory behavior to resolve target SSH settings and fall back to the cloud-init user when no explicit SSH username is set
- Expanded test coverage for SSH configuration, connection resolution, retry handling, quoting, and factory validation
- Closes #1884 

**Added:**

- Production SSH runner - Added builder/proxmox/ssh.go with real golang.org/x/crypto/ssh integration, bounded connection retries, per-command sessions, context cancellation handling, env export rendering, shell-safe quoting, stdin-based file uploads, chmod support, and client cleanup
- SSH behavior tests - Added builder/proxmox/ssh_test.go covering auth requirements, private key parsing, password auth, cloud-init username fallback, retry/cancellation paths, deterministic env ordering, shell quoting, and nil-client close behavior

**Changed:**

- Proxmox runner factory - Updated defaultSSHRunnerFactory to build an SSHConnection from the target and create the real SSH runner instead of returning a placeholder implementation
- Factory tests - Reworked runner tests to assert authentication failures happen before network I/O and that CloudInitUser is accepted as the fallback SSH username
- Dependency classification - Promoted golang.org/x/crypto from indirect to direct in go.mod because the Proxmox builder now imports the SSH package directly

**Removed:**

- Stub SSH implementation - Removed the placeholder runner that only logged commands and always failed Run and UploadFile calls, allowing provisioners to execute against cloned VMs for real