### PR TITLE
fix: encode proxmox cloud-init ssh keys

### DIFF
--- a/builder/proxmox/runner.go
+++ b/builder/proxmox/runner.go
@@ -101,22 +101,7 @@ func (r *liveRunner) clone(ctx context.Context, sourceVMID, newVMID int, name st
 // drive configured, callers should pre-bake one or run with cloud-init
 // disabled by leaving target.CloudInitUser empty.
 func (r *liveRunner) configureCloudInit(ctx context.Context, vm *pveapi.VirtualMachine, target *builder.Target) error {
-	opts := []pveapi.VirtualMachineOption{}
-	if target.CloudInitUser != "" {
-		opts = append(opts, pveapi.VirtualMachineOption{Name: "ciuser", Value: target.CloudInitUser})
-	}
-	if target.CloudInitPassword != "" {
-		opts = append(opts, pveapi.VirtualMachineOption{Name: "cipassword", Value: target.CloudInitPassword})
-	}
-	if target.CloudInitSSHKey != "" {
-		opts = append(opts, pveapi.VirtualMachineOption{Name: "sshkeys", Value: target.CloudInitSSHKey})
-	}
-	if target.CloudInitIPConfig != "" {
-		opts = append(opts, pveapi.VirtualMachineOption{Name: "ipconfig0", Value: target.CloudInitIPConfig})
-	}
-	if target.CloudInitNameserver != "" {
-		opts = append(opts, pveapi.VirtualMachineOption{Name: "nameserver", Value: target.CloudInitNameserver})
-	}
+	opts := buildCloudInitOptions(target)
 	if len(opts) == 0 {
 		return nil
 	}
@@ -125,6 +110,30 @@ func (r *liveRunner) configureCloudInit(ctx context.Context, vm *pveapi.VirtualM
 		return WrapWithRemediation(err, "apply cloud-init config")
 	}
 	return WrapWithRemediation(waitForTask(ctx, task), "wait for cloud-init config")
+}
+
+// buildCloudInitOptions translates target into the PVE VirtualMachineOption
+// slice expected by vm.Config. The sshkeys value goes through
+// pveapi.EncodeSSHKeys because PVE's API validator rejects raw key strings
+// (it requires its specific urlencoded form — see go-proxmox #144).
+func buildCloudInitOptions(target *builder.Target) []pveapi.VirtualMachineOption {
+	opts := []pveapi.VirtualMachineOption{}
+	if target.CloudInitUser != "" {
+		opts = append(opts, pveapi.VirtualMachineOption{Name: "ciuser", Value: target.CloudInitUser})
+	}
+	if target.CloudInitPassword != "" {
+		opts = append(opts, pveapi.VirtualMachineOption{Name: "cipassword", Value: target.CloudInitPassword})
+	}
+	if target.CloudInitSSHKey != "" {
+		opts = append(opts, pveapi.VirtualMachineOption{Name: "sshkeys", Value: pveapi.EncodeSSHKeys(target.CloudInitSSHKey)})
+	}
+	if target.CloudInitIPConfig != "" {
+		opts = append(opts, pveapi.VirtualMachineOption{Name: "ipconfig0", Value: target.CloudInitIPConfig})
+	}
+	if target.CloudInitNameserver != "" {
+		opts = append(opts, pveapi.VirtualMachineOption{Name: "nameserver", Value: target.CloudInitNameserver})
+	}
+	return opts
 }
 
 // startAndWait powers on the VM and waits for the QEMU guest agent.

--- a/builder/proxmox/runner_live_test.go
+++ b/builder/proxmox/runner_live_test.go
@@ -46,6 +46,11 @@ type pveFakeServer struct {
 	calls  []string
 	mu     sync.Mutex
 	taskID string
+
+	// failConfigPOST, when true, makes the server return 500 for any
+	// non-GET request to a /config endpoint. Used to drive
+	// configureCloudInit's error branch.
+	failConfigPOST bool
 }
 
 func newPVEFakeServer(t *testing.T) (*pveFakeServer, *httptest.Server, *pveapi.Client) {
@@ -71,8 +76,13 @@ func (f *pveFakeServer) recorded() []string {
 func (f *pveFakeServer) handle(w http.ResponseWriter, r *http.Request) {
 	f.mu.Lock()
 	f.calls = append(f.calls, r.Method+" "+r.URL.Path)
+	failConfig := f.failConfigPOST
 	f.mu.Unlock()
 	w.Header().Set("Content-Type", "application/json")
+	if failConfig && r.Method != http.MethodGet && strings.HasSuffix(r.URL.Path, "/config") {
+		http.Error(w, `{"errors":{"sshkeys":"forced failure"}}`, http.StatusInternalServerError)
+		return
+	}
 	if body := f.responseFor(r); body != "" {
 		_, _ = w.Write([]byte(body))
 		return
@@ -222,6 +232,35 @@ func TestLiveRunner_Clone(t *testing.T) {
 	}
 	if vm == nil {
 		t.Fatal("expected non-nil cloned VM")
+	}
+}
+
+func TestLiveRunner_ConfigureCloudInit_WrapsConfigError(t *testing.T) {
+	t.Parallel()
+	r, f := newLiveRunnerFor(t)
+	f.mu.Lock()
+	f.failConfigPOST = true
+	f.mu.Unlock()
+
+	// Resolve the VM via the SDK so it has a wired-up client.
+	node, err := r.clients.API.Node(context.Background(), "pve1")
+	if err != nil {
+		t.Fatalf("Node: %v", err)
+	}
+	vm, err := node.VirtualMachine(context.Background(), 9100)
+	if err != nil {
+		t.Fatalf("VirtualMachine: %v", err)
+	}
+	err = r.configureCloudInit(
+		context.Background(),
+		vm,
+		&builder.Target{CloudInitUser: "kali"},
+	)
+	if err == nil {
+		t.Fatal("expected error from /config POST 500")
+	}
+	if !strings.Contains(err.Error(), "apply cloud-init config") {
+		t.Fatalf("expected wrapped context, got %v", err)
 	}
 }
 

--- a/builder/proxmox/runner_test.go
+++ b/builder/proxmox/runner_test.go
@@ -33,6 +33,102 @@ import (
 	"github.com/cowdogmoo/warpgate/v3/builder"
 )
 
+// findOption returns the value paired with name in opts, or "" when name
+// isn't present. Keeps the assertion helpers below readable.
+func findOption(opts []pveapi.VirtualMachineOption, name string) string {
+	for _, o := range opts {
+		if o.Name == name {
+			if s, ok := o.Value.(string); ok {
+				return s
+			}
+		}
+	}
+	return ""
+}
+
+func TestBuildCloudInitOptions_EmptyTargetReturnsNoOptions(t *testing.T) {
+	t.Parallel()
+	if got := buildCloudInitOptions(&builder.Target{}); len(got) != 0 {
+		t.Fatalf("expected empty options for empty target, got %+v", got)
+	}
+}
+
+func TestBuildCloudInitOptions_SSHKeyIsURLEncoded(t *testing.T) {
+	t.Parallel()
+	opts := buildCloudInitOptions(&builder.Target{
+		CloudInitSSHKey: "ssh-ed25519 AAAAC3Nz key@host",
+	})
+	got := findOption(opts, "sshkeys")
+	// PVE's validator requires the Python urllib.parse.quote(s, safe='')
+	// style: spaces as %20, not '+'. Assert the actual encoding rather
+	// than re-implementing it.
+	want := "ssh-ed25519%20AAAAC3Nz%20key%40host"
+	if got != want {
+		t.Fatalf("sshkeys = %q, want %q", got, want)
+	}
+}
+
+func TestBuildCloudInitOptions_SSHKeyEncodingHasNoPlus(t *testing.T) {
+	t.Parallel()
+	// Regression guard: net/url.QueryEscape emits '+' for spaces, which
+	// PVE's sshkeys validator rejects. EncodeSSHKeys must never emit '+'.
+	opts := buildCloudInitOptions(&builder.Target{
+		CloudInitSSHKey: "ssh-rsa AAAA name with spaces",
+	})
+	got := findOption(opts, "sshkeys")
+	if strings.ContainsRune(got, '+') {
+		t.Fatalf("sshkeys must not contain '+'; got %q", got)
+	}
+}
+
+func TestBuildCloudInitOptions_MultipleKeysSeparatorEscaped(t *testing.T) {
+	t.Parallel()
+	opts := buildCloudInitOptions(&builder.Target{
+		CloudInitSSHKey: "ssh-ed25519 AAA one\nssh-ed25519 BBB two",
+	})
+	got := findOption(opts, "sshkeys")
+	// Newlines between keys must be present (as %0A) so PVE installs
+	// both. Embedded spaces in comments must be %20.
+	if !strings.Contains(got, "%0A") {
+		t.Fatalf("expected encoded newline between keys, got %q", got)
+	}
+	if strings.Contains(got, "+") {
+		t.Fatalf("sshkeys must not contain '+'; got %q", got)
+	}
+}
+
+func TestBuildCloudInitOptions_PassesThroughOtherFieldsRaw(t *testing.T) {
+	t.Parallel()
+	opts := buildCloudInitOptions(&builder.Target{
+		CloudInitUser:       "ansible",
+		CloudInitPassword:   "p@ssword!",
+		CloudInitIPConfig:   "ip=dhcp",
+		CloudInitNameserver: "1.1.1.1",
+	})
+	cases := map[string]string{
+		"ciuser":     "ansible",
+		"cipassword": "p@ssword!",
+		"ipconfig0":  "ip=dhcp",
+		"nameserver": "1.1.1.1",
+	}
+	for k, want := range cases {
+		if got := findOption(opts, k); got != want {
+			t.Errorf("%s = %q, want %q", k, got, want)
+		}
+	}
+}
+
+func TestBuildCloudInitOptions_SkipsEmptyFields(t *testing.T) {
+	t.Parallel()
+	opts := buildCloudInitOptions(&builder.Target{CloudInitUser: "only-this"})
+	if len(opts) != 1 {
+		t.Fatalf("expected exactly 1 option, got %d (%+v)", len(opts), opts)
+	}
+	if findOption(opts, "ciuser") != "only-this" {
+		t.Fatalf("unexpected ciuser value: %+v", opts)
+	}
+}
+
 func TestDefaultSSHRunnerFactory_RequiresAuth(t *testing.T) {
 	t.Parallel()
 	// No private key and no password — the factory must fail before any


### PR DESCRIPTION
**Key Changes:**

- Encoded Proxmox cloud-init SSH keys before submitting VM configuration
- Extracted cloud-init option construction for clearer behavior and testability
- Added regression coverage for SSH key encoding, multi-key handling, and empty field filtering
- Closes #1885 

**Added:**

- Cloud-init option builder tests - Covered empty targets, SSH key URL encoding, newline preservation for multiple keys, raw passthrough for non-key fields, and skipping empty fields in builder/proxmox/runner_test.go

**Changed:**

- Proxmox cloud-init configuration flow - Refactored option construction into buildCloudInitOptions and encoded sshkeys with pveapi.EncodeSSHKeys so Proxmox accepts spaces, comments, and multiple keys without rejecting raw or incorrectly escaped values in builder/proxmox/runner.go