### PR TITLE
fix: preserve multiline variable expansion in config loading

### DIFF
--- a/templates/config_loader.go
+++ b/templates/config_loader.go
@@ -82,8 +82,7 @@ func (l *Loader) LoadFromFileWithVars(path string, vars map[string]string) (*bui
 // of every string scalar (mapping keys are left alone). For plain-style
 // scalars whose expanded value is a single line, the tag is re-resolved so
 // an expanded "true"/"123"/"null" still decodes to the corresponding Go
-// type — preserving the pre-fix behavior where text-level substitution
-// would have produced an implicit bool/int/null.
+// type.
 func expandScalarVars(n *yaml.Node, vars map[string]string, expand func(string, map[string]string) string) {
 	if n == nil {
 		return

--- a/templates/config_loader.go
+++ b/templates/config_loader.go
@@ -49,12 +49,17 @@ func (l *Loader) LoadFromFileWithVars(path string, vars map[string]string) (*bui
 		return nil, errors.Wrap("read config file", path, err)
 	}
 
-	// Expand variables in the YAML content
-	// Precedence: CLI vars > Environment variables
-	expandedData := l.expandVariables(string(data), vars)
+	// Parse the YAML first, then expand ${VAR} on string scalars.
+	// Substituting on the raw text would corrupt multi-line values (SSH
+	// keys, PEM blobs) by injecting raw newlines into a YAML scalar.
+	var root yaml.Node
+	if err := yaml.Unmarshal(data, &root); err != nil {
+		return nil, errors.Wrap("parse config file", path, err)
+	}
+	expandScalarVars(&root, vars, l.expandVariables)
 
 	var config builder.Config
-	if err := yaml.Unmarshal([]byte(expandedData), &config); err != nil {
+	if err := root.Decode(&config); err != nil {
 		return nil, errors.Wrap("parse config file", path, err)
 	}
 
@@ -71,6 +76,64 @@ func (l *Loader) LoadFromFileWithVars(path string, vars map[string]string) (*bui
 	l.resolveRelativePaths(&config, baseDir)
 
 	return &config, nil
+}
+
+// expandScalarVars walks the YAML node tree and runs expand over the value
+// of every string scalar (mapping keys are left alone). For plain-style
+// scalars whose expanded value is a single line, the tag is re-resolved so
+// an expanded "true"/"123"/"null" still decodes to the corresponding Go
+// type — preserving the pre-fix behavior where text-level substitution
+// would have produced an implicit bool/int/null.
+func expandScalarVars(n *yaml.Node, vars map[string]string, expand func(string, map[string]string) string) {
+	if n == nil {
+		return
+	}
+	switch n.Kind {
+	case yaml.DocumentNode, yaml.SequenceNode:
+		for _, c := range n.Content {
+			expandScalarVars(c, vars, expand)
+		}
+	case yaml.MappingNode:
+		// Mapping content alternates [key, value, key, value, ...].
+		// Skip keys (i even) and expand values (i odd).
+		for i := 1; i < len(n.Content); i += 2 {
+			expandScalarVars(n.Content[i], vars, expand)
+		}
+	case yaml.ScalarNode:
+		if n.Tag != "" && n.Tag != "!!str" {
+			return
+		}
+		old := n.Value
+		expanded := expand(old, vars)
+		if expanded == old {
+			return
+		}
+		n.Value = expanded
+		if n.Style == 0 && !strings.ContainsRune(expanded, '\n') {
+			if tag := inferScalarTag(expanded); tag != "" {
+				n.Tag = tag
+			}
+		}
+	}
+}
+
+// inferScalarTag re-parses s as a standalone YAML document and returns the
+// resolved tag of the resulting scalar (e.g. "!!bool", "!!int"). Returns ""
+// when s isn't a parseable single scalar so the caller leaves the existing
+// tag in place.
+func inferScalarTag(s string) string {
+	var doc yaml.Node
+	if err := yaml.Unmarshal([]byte(s), &doc); err != nil {
+		return ""
+	}
+	if len(doc.Content) == 0 {
+		return ""
+	}
+	c := doc.Content[0]
+	if c.Kind != yaml.ScalarNode {
+		return ""
+	}
+	return c.Tag
 }
 
 // expandVariables expands ${VAR} style variables only

--- a/templates/config_loader_test.go
+++ b/templates/config_loader_test.go
@@ -4441,18 +4441,6 @@ func TestGetLatestVersionEmpty(t *testing.T) {
 	assert.Contains(t, err.Error(), "no versions provided")
 }
 
-// ---------------------------------------------------------------------------
-// config_loader.go: multi-line env-var substitution (regression for #1886).
-// Pre-fix, expandVariables ran on the raw YAML text so a multi-line value
-// injected raw newlines into a scalar and broke the YAML parse. The new
-// node-walking expansion treats env values as literal scalar data.
-// ---------------------------------------------------------------------------
-
-// multilineValue is a generic multi-line payload used to exercise the
-// regression in #1886. The exact content doesn't matter — only that it
-// contains newlines, which the old text-level expansion would have
-// injected raw into the YAML and broken the parse. We avoid PEM-shaped
-// strings so the secret-detect pre-commit hook doesn't flag the test.
 const multilineValue = `first line
 second line with: colon
 third line`
@@ -4490,9 +4478,6 @@ targets:
 	require.NoError(t, err)
 	require.Len(t, cfg.Provisioners, 1)
 	require.Len(t, cfg.Provisioners[0].Inline, 1)
-	// The whole multi-line value round-trips into the scalar, newlines
-	// intact, without breaking the surrounding YAML structure
-	// (target type, user, etc.).
 	assert.Equal(t, multilineValue, cfg.Provisioners[0].Inline[0])
 	assert.Equal(t, "deploy", cfg.Provisioners[0].User)
 }
@@ -4568,9 +4553,6 @@ targets:
 }
 
 func TestExpandScalarVars_ReTagsPlainBool(t *testing.T) {
-	// Plain-style scalar that becomes "true" after substitution should
-	// decode as a bool so downstream struct fields keep their old type
-	// behaviour. Quoted scalars stay strings.
 	src := []byte("pull: ${FLAG}\nname: ${NAME}\n")
 	var n yaml.Node
 	require.NoError(t, yaml.Unmarshal(src, &n))
@@ -4596,9 +4578,6 @@ func TestExpandScalarVars_ReTagsPlainBool(t *testing.T) {
 }
 
 func TestExpandScalarVars_MultilineStaysString(t *testing.T) {
-	// Even if the expanded value contains "true" on one of its lines, a
-	// multi-line value must not be re-tagged as bool — that would lose
-	// the body.
 	src := []byte("key: ${K}\n")
 	var n yaml.Node
 	require.NoError(t, yaml.Unmarshal(src, &n))
@@ -4619,9 +4598,6 @@ func TestExpandScalarVars_MultilineStaysString(t *testing.T) {
 }
 
 func TestExpandScalarVars_SkipsNonStringScalars(t *testing.T) {
-	// !!int, !!bool, !!null scalars must be left alone by the expander —
-	// they can't contain ${VAR} syntax anyway and re-walking them risks
-	// changing their tag.
 	src := []byte("count: 5\nflag: false\nempty: null\n")
 	var n yaml.Node
 	require.NoError(t, yaml.Unmarshal(src, &n))
@@ -4636,8 +4612,6 @@ func TestExpandScalarVars_SkipsNonStringScalars(t *testing.T) {
 }
 
 func TestExpandScalarVars_NoChangeEarlyReturns(t *testing.T) {
-	// When the expander returns the input unchanged, the walker must
-	// leave the node alone (no re-tagging, no Value mutation).
 	src := []byte("key: literal\n")
 	var n yaml.Node
 	require.NoError(t, yaml.Unmarshal(src, &n))
@@ -4653,7 +4627,6 @@ func TestExpandScalarVars_NoChangeEarlyReturns(t *testing.T) {
 }
 
 func TestExpandScalarVars_NilNodeIsNoOp(t *testing.T) {
-	// Guard: defensive nil check shouldn't panic when called directly.
 	expandScalarVars(nil, nil, func(s string, _ map[string]string) string { return s })
 }
 
@@ -4673,28 +4646,18 @@ func TestInferScalarTag_ReturnsStdlibTagsForKnownTypes(t *testing.T) {
 }
 
 func TestInferScalarTag_UnparseableReturnsEmpty(t *testing.T) {
-	// A value that parses as a mapping (not a scalar) should not produce
-	// a tag — the caller will keep the original tag.
 	assert.Equal(t, "", inferScalarTag("{a: 1, b: 2}"))
 }
 
 func TestInferScalarTag_MalformedYAMLReturnsEmpty(t *testing.T) {
-	// Unterminated flow mapping is a real parse error, not a typed
-	// scalar — the helper must swallow that and return "".
 	assert.Equal(t, "", inferScalarTag("{a:"))
 }
 
 func TestInferScalarTag_EmptyInputReturnsEmpty(t *testing.T) {
-	// Empty input parses as an empty document with no content; helper
-	// must return "" so the caller keeps the original tag.
 	assert.Equal(t, "", inferScalarTag(""))
 }
 
 func TestLoadFromFileWithVars_DecodeErrorWrapped(t *testing.T) {
-	// YAML that parses as a node tree but doesn't fit builder.Config:
-	// `targets` must be a sequence, not a string. The new flow surfaces
-	// this in the Decode step (separate from yaml.Unmarshal) and must
-	// still return a "parse config file" wrapped error.
 	tmpDir := t.TempDir()
 	bad := filepath.Join(tmpDir, "shape.yaml")
 	content := `metadata:

--- a/templates/config_loader_test.go
+++ b/templates/config_loader_test.go
@@ -4440,3 +4440,279 @@ func TestGetLatestVersionEmpty(t *testing.T) {
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "no versions provided")
 }
+
+// ---------------------------------------------------------------------------
+// config_loader.go: multi-line env-var substitution (regression for #1886).
+// Pre-fix, expandVariables ran on the raw YAML text so a multi-line value
+// injected raw newlines into a scalar and broke the YAML parse. The new
+// node-walking expansion treats env values as literal scalar data.
+// ---------------------------------------------------------------------------
+
+// multilineValue is a generic multi-line payload used to exercise the
+// regression in #1886. The exact content doesn't matter — only that it
+// contains newlines, which the old text-level expansion would have
+// injected raw into the YAML and broken the parse. We avoid PEM-shaped
+// strings so the secret-detect pre-commit hook doesn't flag the test.
+const multilineValue = `first line
+second line with: colon
+third line`
+
+func TestLoadFromFileWithVars_MultilineValueParses(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "warpgate.yaml")
+	content := `metadata:
+  name: ml-test
+  version: 1.0.0
+  description: Multi-line var
+  author: Test
+  license: MIT
+  requires:
+    warpgate: ">=1.0.0"
+name: ml-test
+version: latest
+base:
+  image: alpine:latest
+provisioners:
+  - type: shell
+    inline:
+      - ${PRIVATE_KEY}
+    user: deploy
+targets:
+  - type: container
+    platforms:
+      - linux/amd64
+`
+	require.NoError(t, os.WriteFile(configPath, []byte(content), 0644))
+
+	cfg, err := NewLoader().LoadFromFileWithVars(configPath, map[string]string{
+		"PRIVATE_KEY": multilineValue,
+	})
+	require.NoError(t, err)
+	require.Len(t, cfg.Provisioners, 1)
+	require.Len(t, cfg.Provisioners[0].Inline, 1)
+	// The whole multi-line value round-trips into the scalar, newlines
+	// intact, without breaking the surrounding YAML structure
+	// (target type, user, etc.).
+	assert.Equal(t, multilineValue, cfg.Provisioners[0].Inline[0])
+	assert.Equal(t, "deploy", cfg.Provisioners[0].User)
+}
+
+func TestLoadFromFileWithVars_PartialSubstitutionStillWorks(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "warpgate.yaml")
+	content := `metadata:
+  name: part-test
+  version: 1.0.0
+  description: Partial sub
+  author: Test
+  license: MIT
+  requires:
+    warpgate: ">=1.0.0"
+name: part-test
+version: latest
+base:
+  image: alpine:latest
+provisioners:
+  - type: script
+    scripts:
+      - ${SCRIPT_DIR}/install.sh
+targets:
+  - type: container
+    platforms:
+      - linux/amd64
+`
+	require.NoError(t, os.WriteFile(configPath, []byte(content), 0644))
+
+	cfg, err := NewLoader().LoadFromFileWithVars(configPath, map[string]string{
+		"SCRIPT_DIR": "/opt/scripts",
+	})
+	require.NoError(t, err)
+	require.Len(t, cfg.Provisioners[0].Scripts, 1)
+	assert.Equal(t, "/opt/scripts/install.sh", cfg.Provisioners[0].Scripts[0])
+}
+
+func TestLoadFromFileWithVars_PreservesSourcesReferences(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "warpgate.yaml")
+	// Use a shell inline command so the value isn't run through
+	// MustExpandPath (which would strip ${sources.*} via os.ExpandEnv).
+	content := `metadata:
+  name: src-test
+  version: 1.0.0
+  description: Sources passthrough
+  author: Test
+  license: MIT
+  requires:
+    warpgate: ">=1.0.0"
+name: src-test
+version: latest
+base:
+  image: alpine:latest
+provisioners:
+  - type: shell
+    inline:
+      - "cp ${sources.collection}/playbook.yml /etc/playbook.yml"
+targets:
+  - type: container
+    platforms:
+      - linux/amd64
+`
+	require.NoError(t, os.WriteFile(configPath, []byte(content), 0644))
+
+	cfg, err := NewLoader().LoadFromFileWithVars(configPath, nil)
+	require.NoError(t, err)
+	require.Len(t, cfg.Provisioners[0].Inline, 1)
+	// ${sources.*} references must survive the loader so the sources
+	// pipeline can resolve them after the sources are fetched.
+	assert.Contains(t, cfg.Provisioners[0].Inline[0], "${sources.collection}")
+}
+
+func TestExpandScalarVars_ReTagsPlainBool(t *testing.T) {
+	// Plain-style scalar that becomes "true" after substitution should
+	// decode as a bool so downstream struct fields keep their old type
+	// behaviour. Quoted scalars stay strings.
+	src := []byte("pull: ${FLAG}\nname: ${NAME}\n")
+	var n yaml.Node
+	require.NoError(t, yaml.Unmarshal(src, &n))
+
+	expand := func(s string, _ map[string]string) string {
+		if s == "${FLAG}" {
+			return "true"
+		}
+		if s == "${NAME}" {
+			return "alpine"
+		}
+		return s
+	}
+	expandScalarVars(&n, nil, expand)
+
+	var got struct {
+		Pull bool   `yaml:"pull"`
+		Name string `yaml:"name"`
+	}
+	require.NoError(t, n.Decode(&got))
+	assert.True(t, got.Pull)
+	assert.Equal(t, "alpine", got.Name)
+}
+
+func TestExpandScalarVars_MultilineStaysString(t *testing.T) {
+	// Even if the expanded value contains "true" on one of its lines, a
+	// multi-line value must not be re-tagged as bool — that would lose
+	// the body.
+	src := []byte("key: ${K}\n")
+	var n yaml.Node
+	require.NoError(t, yaml.Unmarshal(src, &n))
+
+	expand := func(s string, _ map[string]string) string {
+		if s == "${K}" {
+			return "line one\ntrue\nline three"
+		}
+		return s
+	}
+	expandScalarVars(&n, nil, expand)
+
+	var got struct {
+		Key string `yaml:"key"`
+	}
+	require.NoError(t, n.Decode(&got))
+	assert.Equal(t, "line one\ntrue\nline three", got.Key)
+}
+
+func TestExpandScalarVars_SkipsNonStringScalars(t *testing.T) {
+	// !!int, !!bool, !!null scalars must be left alone by the expander —
+	// they can't contain ${VAR} syntax anyway and re-walking them risks
+	// changing their tag.
+	src := []byte("count: 5\nflag: false\nempty: null\n")
+	var n yaml.Node
+	require.NoError(t, yaml.Unmarshal(src, &n))
+
+	calls := 0
+	expand := func(s string, _ map[string]string) string {
+		calls++
+		return s + "-touched"
+	}
+	expandScalarVars(&n, nil, expand)
+	assert.Equal(t, 0, calls, "expander should not be called for non-string scalars")
+}
+
+func TestExpandScalarVars_NoChangeEarlyReturns(t *testing.T) {
+	// When the expander returns the input unchanged, the walker must
+	// leave the node alone (no re-tagging, no Value mutation).
+	src := []byte("key: literal\n")
+	var n yaml.Node
+	require.NoError(t, yaml.Unmarshal(src, &n))
+
+	identity := func(s string, _ map[string]string) string { return s }
+	expandScalarVars(&n, nil, identity)
+
+	var got struct {
+		Key string `yaml:"key"`
+	}
+	require.NoError(t, n.Decode(&got))
+	assert.Equal(t, "literal", got.Key)
+}
+
+func TestExpandScalarVars_NilNodeIsNoOp(t *testing.T) {
+	// Guard: defensive nil check shouldn't panic when called directly.
+	expandScalarVars(nil, nil, func(s string, _ map[string]string) string { return s })
+}
+
+func TestInferScalarTag_ReturnsStdlibTagsForKnownTypes(t *testing.T) {
+	cases := map[string]string{
+		"true":  "!!bool",
+		"false": "!!bool",
+		"123":   "!!int",
+		"1.5":   "!!float",
+		"null":  "!!null",
+		"hello": "!!str",
+	}
+	for in, want := range cases {
+		got := inferScalarTag(in)
+		assert.Equal(t, want, got, "inferScalarTag(%q)", in)
+	}
+}
+
+func TestInferScalarTag_UnparseableReturnsEmpty(t *testing.T) {
+	// A value that parses as a mapping (not a scalar) should not produce
+	// a tag — the caller will keep the original tag.
+	assert.Equal(t, "", inferScalarTag("{a: 1, b: 2}"))
+}
+
+func TestInferScalarTag_MalformedYAMLReturnsEmpty(t *testing.T) {
+	// Unterminated flow mapping is a real parse error, not a typed
+	// scalar — the helper must swallow that and return "".
+	assert.Equal(t, "", inferScalarTag("{a:"))
+}
+
+func TestInferScalarTag_EmptyInputReturnsEmpty(t *testing.T) {
+	// Empty input parses as an empty document with no content; helper
+	// must return "" so the caller keeps the original tag.
+	assert.Equal(t, "", inferScalarTag(""))
+}
+
+func TestLoadFromFileWithVars_DecodeErrorWrapped(t *testing.T) {
+	// YAML that parses as a node tree but doesn't fit builder.Config:
+	// `targets` must be a sequence, not a string. The new flow surfaces
+	// this in the Decode step (separate from yaml.Unmarshal) and must
+	// still return a "parse config file" wrapped error.
+	tmpDir := t.TempDir()
+	bad := filepath.Join(tmpDir, "shape.yaml")
+	content := `metadata:
+  name: bad
+  version: 1.0.0
+  description: bad
+  author: x
+  license: MIT
+  requires:
+    warpgate: ">=1.0.0"
+name: bad
+version: latest
+base:
+  image: alpine
+targets: "this should be a list"
+`
+	require.NoError(t, os.WriteFile(bad, []byte(content), 0644))
+	_, err := NewLoader().LoadFromFileWithVars(bad, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "parse config file")
+}


### PR DESCRIPTION
**Key Changes:**

- Fixed config loading so multiline environment or CLI variables no longer corrupt YAML parsing
- Changed variable expansion to operate on parsed YAML scalar nodes instead of raw YAML text
- Preserved existing implicit type behavior for expanded plain scalars like booleans, integers, floats, and null values
- Added regression coverage for multiline secrets, partial substitutions, source references, scalar tagging, and decode errors

**Added:**

- YAML scalar variable expansion helpers - Added node-walking expansion and scalar tag inference so string values can be safely expanded after YAML parsing
- Multiline variable regression coverage - Added tests ensuring multiline values round-trip intact in provisioner inline commands without breaking surrounding config structure
- Scalar behavior coverage - Added tests for bool re-tagging, multiline string preservation, skipped non-string scalars, no-op expansion, nil node handling, and tag inference edge cases
- Loader error coverage - Added a decode failure test to confirm invalid config shapes still return wrapped parse config errors

**Changed:**

- Config loading flow - Updated LoadFromFileWithVars to parse YAML into a node tree first, expand variables only in string scalar values, then decode into the builder config
- Variable substitution semantics - Preserved CLI-over-environment precedence while avoiding raw text substitution that could inject unescaped newlines into YAML scalars
- YAML type preservation - Re-resolved tags for expanded plain single-line scalars so values such as true, 123, 1.5, and null continue decoding to their expected Go types
- Source reference handling - Ensured unresolved source placeholders remain intact for later source pipeline resolution instead of being altered during config loading