### PR TITLE
feat: add sudo and directory support for proxmox provisioners

### DIFF
--- a/builder/config.go
+++ b/builder/config.go
@@ -399,6 +399,11 @@ type Provisioner struct {
 
 	// User specifies which user to run the provisioner as
 	User string `yaml:"user,omitempty" json:"user,omitempty"`
+
+	// Sudo elevates privileges when running shell/file/script provisioners over SSH.
+	// Only meaningful for Linux Proxmox builds where the SSH user has NOPASSWD sudo;
+	// other backends ignore it. When combined with User the User wrap takes precedence.
+	Sudo bool `yaml:"sudo,omitempty" json:"sudo,omitempty"`
 }
 
 // Target represents a build target

--- a/builder/proxmox/provisioners.go
+++ b/builder/proxmox/provisioners.go
@@ -39,12 +39,27 @@ type SSHRunner interface {
 	// streamed into the returned string for callers that want to log it.
 	Run(ctx context.Context, command string, env map[string]string) (string, error)
 
-	// UploadFile copies a local file (or directory) to a destination path
-	// on the remote host with the given mode.
-	UploadFile(ctx context.Context, source, destination, mode string) error
+	// UploadFile copies a local file or directory to a destination path on
+	// the remote host. Directories are uploaded recursively via a tar
+	// pipeline. opts controls permissions and privilege escalation.
+	UploadFile(ctx context.Context, source, destination string, opts UploadOptions) error
 
 	// Close releases the underlying SSH session.
 	Close() error
+}
+
+// UploadOptions controls how SSHRunner.UploadFile transfers a file or
+// directory tree.
+type UploadOptions struct {
+	// Mode is the file permission applied via chmod after transfer
+	// (e.g., "0644"). Empty skips chmod. For directory uploads the mode
+	// is applied to the destination directory itself, not its contents.
+	Mode string
+
+	// Sudo elevates privileges for the remote write, mkdir, and chmod.
+	// Required when the destination is owned by a different user than
+	// the SSH login user (e.g., writing into /root or /etc).
+	Sudo bool
 }
 
 // SSHConnection bundles connection parameters for an SSHRunner.
@@ -107,23 +122,30 @@ func runShellProvisioner(ctx context.Context, runner SSHRunner, p builder.Provis
 	if p.WorkingDir != "" {
 		cmd = fmt.Sprintf("cd %q && %s", p.WorkingDir, cmd)
 	}
-	if p.User != "" {
-		// Use sudo -u so env vars propagate correctly via sudo -E.
+	switch {
+	case p.User != "":
+		// Use sudo -u so env vars propagate correctly via sudo -E. When
+		// both User and Sudo are set, this wrap already elevates so we
+		// skip the plain sudo wrap below.
 		cmd = fmt.Sprintf("sudo -E -u %s -- sh -c %q", p.User, cmd)
+	case p.Sudo:
+		// sudo -E preserves env exports emitted by withEnvExports.
+		cmd = fmt.Sprintf("sudo -E sh -c %q", cmd)
 	}
 	out, err := runner.Run(ctx, cmd, p.Environment)
-	if out != "" {
-		logging.DebugContext(ctx, "shell output: %s", out)
-	}
+	logProvisionerOutput(ctx, "shell", out, err)
 	return err
 }
 
-// runFileProvisioner uploads source to destination with mode.
+// runFileProvisioner uploads source (file or directory) to destination.
 func runFileProvisioner(ctx context.Context, runner SSHRunner, p builder.Provisioner) error {
 	if p.Source == "" || p.Destination == "" {
 		return fmt.Errorf("file provisioner requires source and destination")
 	}
-	return runner.UploadFile(ctx, p.Source, p.Destination, p.Mode)
+	return runner.UploadFile(ctx, p.Source, p.Destination, UploadOptions{
+		Mode: p.Mode,
+		Sudo: p.Sudo,
+	})
 }
 
 // runScriptProvisioner uploads each script and executes it on the remote
@@ -131,13 +153,15 @@ func runFileProvisioner(ctx context.Context, runner SSHRunner, p builder.Provisi
 func runScriptProvisioner(ctx context.Context, runner SSHRunner, p builder.Provisioner) error {
 	for _, script := range p.Scripts {
 		remote := fmt.Sprintf("/tmp/warpgate-%s", filepathBase(script))
-		if err := runner.UploadFile(ctx, script, remote, "0755"); err != nil {
+		if err := runner.UploadFile(ctx, script, remote, UploadOptions{Mode: "0755"}); err != nil {
 			return fmt.Errorf("upload %s: %w", script, err)
 		}
-		out, err := runner.Run(ctx, remote, p.Environment)
-		if out != "" {
-			logging.DebugContext(ctx, "script %s output: %s", script, out)
+		cmd := remote
+		if p.Sudo {
+			cmd = "sudo -E " + remote
 		}
+		out, err := runner.Run(ctx, cmd, p.Environment)
+		logProvisionerOutput(ctx, fmt.Sprintf("script %s", script), out, err)
 		if err != nil {
 			return err
 		}
@@ -154,7 +178,7 @@ func runPowerShellProvisioner(ctx context.Context, runner SSHRunner, p builder.P
 	}
 	for _, script := range p.PSScripts {
 		remote := fmt.Sprintf("C:\\Windows\\Temp\\warpgate-%s", filepathBase(script))
-		if err := runner.UploadFile(ctx, script, remote, ""); err != nil {
+		if err := runner.UploadFile(ctx, script, remote, UploadOptions{}); err != nil {
 			return fmt.Errorf("upload %s: %w", script, err)
 		}
 		cmd := fmt.Sprintf("powershell.exe -ExecutionPolicy %s -File %s", policy, remote)
@@ -163,6 +187,22 @@ func runPowerShellProvisioner(ctx context.Context, runner SSHRunner, p builder.P
 		}
 	}
 	return nil
+}
+
+// logProvisionerOutput routes captured remote output to the appropriate
+// level. On failure the output is the only diagnostic available, so it
+// surfaces at warn level regardless of --log-level. On success it stays
+// at debug since it can be high-volume.
+func logProvisionerOutput(ctx context.Context, label, out string, err error) {
+	out = strings.TrimSpace(out)
+	if out == "" {
+		return
+	}
+	if err != nil {
+		logging.WarnContext(ctx, "%s output (failed): %s", label, out)
+		return
+	}
+	logging.DebugContext(ctx, "%s output: %s", label, out)
 }
 
 // filepathBase returns the trailing element of a path without importing

--- a/builder/proxmox/provisioners_test.go
+++ b/builder/proxmox/provisioners_test.go
@@ -40,7 +40,10 @@ type fakeRunner struct {
 	closed   bool
 }
 
-type upload struct{ src, dst, mode string }
+type upload struct {
+	src, dst, mode string
+	sudo           bool
+}
 
 func (f *fakeRunner) Run(_ context.Context, cmd string, _ map[string]string) (string, error) {
 	f.commands = append(f.commands, cmd)
@@ -50,8 +53,8 @@ func (f *fakeRunner) Run(_ context.Context, cmd string, _ map[string]string) (st
 	return "ok\n", nil
 }
 
-func (f *fakeRunner) UploadFile(_ context.Context, src, dst, mode string) error {
-	f.uploads = append(f.uploads, upload{src, dst, mode})
+func (f *fakeRunner) UploadFile(_ context.Context, src, dst string, opts UploadOptions) error {
+	f.uploads = append(f.uploads, upload{src, dst, opts.Mode, opts.Sudo})
 	if f.failUp {
 		return errors.New("upload failed")
 	}
@@ -150,8 +153,62 @@ func TestRunProvisioners_File(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
-	if len(r.uploads) != 1 || r.uploads[0] != (upload{"src.tar", "/opt/dst.tar", "0644"}) {
+	if len(r.uploads) != 1 || r.uploads[0] != (upload{"src.tar", "/opt/dst.tar", "0644", false}) {
 		t.Fatalf("unexpected uploads: %+v", r.uploads)
+	}
+}
+
+func TestRunProvisioners_FilePropagatesSudo(t *testing.T) {
+	t.Parallel()
+	r := &fakeRunner{}
+	err := runProvisioners(context.Background(), r, []builder.Provisioner{{
+		Type:        "file",
+		Source:      "src.tar",
+		Destination: "/root/dst.tar",
+		Mode:        "0600",
+		Sudo:        true,
+	}})
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if len(r.uploads) != 1 || !r.uploads[0].sudo {
+		t.Fatalf("expected sudo upload, got %+v", r.uploads)
+	}
+}
+
+func TestRunProvisioners_ShellWithSudo(t *testing.T) {
+	t.Parallel()
+	r := &fakeRunner{}
+	err := runProvisioners(context.Background(), r, []builder.Provisioner{{
+		Type:   "shell",
+		Inline: []string{"echo hi"},
+		Sudo:   true,
+	}})
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if !strings.Contains(r.commands[0], "sudo -E sh -c") {
+		t.Fatalf("expected sudo wrap, got %q", r.commands[0])
+	}
+}
+
+func TestRunProvisioners_ShellUserBeatsSudo(t *testing.T) {
+	t.Parallel()
+	r := &fakeRunner{}
+	err := runProvisioners(context.Background(), r, []builder.Provisioner{{
+		Type:   "shell",
+		Inline: []string{"true"},
+		User:   "kali",
+		Sudo:   true,
+	}})
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if !strings.Contains(r.commands[0], "sudo -E -u kali") {
+		t.Fatalf("expected user wrap to take precedence, got %q", r.commands[0])
+	}
+	if strings.Contains(r.commands[0], "sudo -E sh -c") {
+		t.Fatalf("plain sudo wrap should not stack on top of user wrap, got %q", r.commands[0])
 	}
 }
 
@@ -179,6 +236,22 @@ func TestRunProvisioners_Script(t *testing.T) {
 	}
 	if len(r.commands) != 1 || !strings.HasSuffix(r.commands[0], "install.sh") {
 		t.Fatalf("expected execution of uploaded script, got %+v", r.commands)
+	}
+}
+
+func TestRunProvisioners_ScriptWithSudo(t *testing.T) {
+	t.Parallel()
+	r := &fakeRunner{}
+	err := runProvisioners(context.Background(), r, []builder.Provisioner{{
+		Type:    "script",
+		Scripts: []string{"install.sh"},
+		Sudo:    true,
+	}})
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if !strings.HasPrefix(r.commands[0], "sudo -E ") {
+		t.Fatalf("expected sudo prefix on script execution, got %q", r.commands[0])
 	}
 }
 

--- a/builder/proxmox/provisioners_test.go
+++ b/builder/proxmox/provisioners_test.go
@@ -23,12 +23,15 @@ THE SOFTWARE.
 package proxmox
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"log/slog"
 	"strings"
 	"testing"
 
 	"github.com/cowdogmoo/warpgate/v3/builder"
+	"github.com/cowdogmoo/warpgate/v3/logging"
 )
 
 // fakeRunner is a test double for SSHRunner that records every call.
@@ -331,6 +334,81 @@ func TestRunProvisioners_RunFailurePropagates(t *testing.T) {
 	}})
 	if err == nil {
 		t.Fatal("expected run failure to propagate")
+	}
+}
+
+func TestLogProvisionerOutput_FailureRoutesToWarn(t *testing.T) {
+	t.Parallel()
+	// LogLevel=Warn would suppress Debug but pass Warn. If failed output
+	// reached Warn it survives; if it stayed at Debug it would be dropped.
+	buf := &bytes.Buffer{}
+	logger := logging.NewCustomLogger(slog.LevelWarn)
+	logger.ConsoleWriter = buf
+	ctx := logging.WithLogger(context.Background(), logger)
+
+	logProvisionerOutput(ctx, "shell", "stderr line\n", errors.New("exit 100"))
+
+	if !bytes.Contains(buf.Bytes(), []byte("shell output (failed): stderr line")) {
+		t.Fatalf("expected failure message at warn level, got %q", buf.String())
+	}
+}
+
+func TestLogProvisionerOutput_SuccessStaysDebug(t *testing.T) {
+	t.Parallel()
+	// At LogLevel=Info, Debug is suppressed — successful output should
+	// stay debug and produce nothing.
+	buf := &bytes.Buffer{}
+	logger := logging.NewCustomLogger(slog.LevelInfo)
+	logger.ConsoleWriter = buf
+	ctx := logging.WithLogger(context.Background(), logger)
+
+	logProvisionerOutput(ctx, "shell", "ok\n", nil)
+
+	if buf.Len() != 0 {
+		t.Fatalf("expected success output to stay debug-level (suppressed), got %q", buf.String())
+	}
+}
+
+func TestLogProvisionerOutput_EmptyOutputSkipped(t *testing.T) {
+	t.Parallel()
+	buf := &bytes.Buffer{}
+	logger := logging.NewCustomLogger(slog.LevelDebug)
+	logger.ConsoleWriter = buf
+	ctx := logging.WithLogger(context.Background(), logger)
+
+	logProvisionerOutput(ctx, "shell", "   \n", nil)
+
+	if buf.Len() != 0 {
+		t.Fatalf("expected no output when remote output is empty, got %q", buf.String())
+	}
+}
+
+// scriptFailRunner runs UploadFile fine but returns an error with output
+// for Run, exercising the on-failure logging branch in runScriptProvisioner.
+type scriptFailRunner struct{ fakeRunner }
+
+func (r *scriptFailRunner) Run(_ context.Context, cmd string, _ map[string]string) (string, error) {
+	r.commands = append(r.commands, cmd)
+	return "boom\n", errors.New("exit 100")
+}
+
+func TestRunProvisioners_ScriptFailureSurfacesOutput(t *testing.T) {
+	t.Parallel()
+	buf := &bytes.Buffer{}
+	logger := logging.NewCustomLogger(slog.LevelInfo)
+	logger.ConsoleWriter = buf
+	ctx := logging.WithLogger(context.Background(), logger)
+
+	r := &scriptFailRunner{}
+	err := runProvisioners(ctx, r, []builder.Provisioner{{
+		Type:    "script",
+		Scripts: []string{"/local/install.sh"},
+	}})
+	if err == nil {
+		t.Fatal("expected script error to propagate")
+	}
+	if !bytes.Contains(buf.Bytes(), []byte("script /local/install.sh output (failed): boom")) {
+		t.Fatalf("expected failure output captured, got %q", buf.String())
 	}
 }
 

--- a/builder/proxmox/ssh.go
+++ b/builder/proxmox/ssh.go
@@ -23,12 +23,15 @@ THE SOFTWARE.
 package proxmox
 
 import (
+	"archive/tar"
 	"bytes"
 	"context"
 	"fmt"
 	"io"
+	"io/fs"
 	"net"
 	"os"
+	"path/filepath"
 	"sort"
 	"strconv"
 	"strings"
@@ -172,19 +175,41 @@ func (s *sshRunner) Run(ctx context.Context, command string, env map[string]stri
 	return out.String(), nil
 }
 
-// UploadFile copies source to destination by piping the file body to a
-// remote `cat > destination`. Mode is applied with chmod afterwards. Using
-// cat-over-stdin avoids pulling in an SCP/SFTP dep.
-func (s *sshRunner) UploadFile(ctx context.Context, source, destination, mode string) error {
+// UploadFile copies source to destination over SSH. Regular files stream
+// through `cat > destination` (or `sudo tee` when elevation is requested).
+// Directories are streamed as an in-process tar archive piped into a remote
+// `tar -xf -`, which preserves permissions and symlinks without requiring
+// SCP/SFTP on either side.
+func (s *sshRunner) UploadFile(ctx context.Context, source, destination string, opts UploadOptions) error {
+	info, err := os.Stat(source)
+	if err != nil {
+		return fmt.Errorf("stat source %s: %w", source, err)
+	}
+	if info.IsDir() {
+		return s.uploadDir(ctx, source, destination, opts)
+	}
+	return s.uploadRegularFile(ctx, source, destination, opts)
+}
+
+// uploadRegularFile pipes a single file's body to the remote host.
+func (s *sshRunner) uploadRegularFile(ctx context.Context, source, destination string, opts UploadOptions) error {
 	f, err := os.Open(source)
 	if err != nil {
 		return fmt.Errorf("open source %s: %w", source, err)
 	}
 	defer func() { _ = f.Close() }()
 
+	// `tee` overwrites the destination by default; `cat > path` does the
+	// same in the non-sudo path. Both create the file when missing.
+	var writeCmd string
+	if opts.Sudo {
+		writeCmd = fmt.Sprintf("sudo tee %s >/dev/null", shellQuote(destination))
+	} else {
+		writeCmd = fmt.Sprintf("cat > %s", shellQuote(destination))
+	}
+
 	var errBuf bytes.Buffer
-	cmd := fmt.Sprintf("cat > %s", shellQuote(destination))
-	if err := s.runCmd(ctx, cmd, f, io.Discard, &errBuf); err != nil {
+	if err := s.runCmd(ctx, writeCmd, f, io.Discard, &errBuf); err != nil {
 		stderr := strings.TrimSpace(errBuf.String())
 		if stderr != "" {
 			return fmt.Errorf("upload %s -> %s: %w (%s)", source, destination, err, stderr)
@@ -192,13 +217,118 @@ func (s *sshRunner) UploadFile(ctx context.Context, source, destination, mode st
 		return fmt.Errorf("upload %s -> %s: %w", source, destination, err)
 	}
 
-	if mode != "" {
-		chmod := fmt.Sprintf("chmod %s %s", shellQuote(mode), shellQuote(destination))
+	if opts.Mode != "" {
+		chmod := fmt.Sprintf("chmod %s %s", shellQuote(opts.Mode), shellQuote(destination))
+		if opts.Sudo {
+			chmod = "sudo " + chmod
+		}
 		if _, err := s.Run(ctx, chmod, nil); err != nil {
-			return fmt.Errorf("chmod %s %s: %w", mode, destination, err)
+			return fmt.Errorf("chmod %s %s: %w", opts.Mode, destination, err)
 		}
 	}
 	return nil
+}
+
+// uploadDir streams source as a tar archive into a remote `tar -xf -`. The
+// destination is created if missing; archive entries are written relative
+// to it so the directory's contents end up under destination/.
+func (s *sshRunner) uploadDir(ctx context.Context, source, destination string, opts UploadOptions) error {
+	mkdir := fmt.Sprintf("mkdir -p %s", shellQuote(destination))
+	if opts.Sudo {
+		mkdir = "sudo " + mkdir
+	}
+	if _, err := s.Run(ctx, mkdir, nil); err != nil {
+		return fmt.Errorf("mkdir %s: %w", destination, err)
+	}
+
+	pr, pw := io.Pipe()
+	go func() {
+		tw := tar.NewWriter(pw)
+		writeErr := writeDirAsTar(tw, source)
+		closeErr := tw.Close()
+		if writeErr == nil {
+			writeErr = closeErr
+		}
+		_ = pw.CloseWithError(writeErr)
+	}()
+
+	extract := fmt.Sprintf("tar -C %s -xf -", shellQuote(destination))
+	if opts.Sudo {
+		extract = "sudo " + extract
+	}
+
+	var errBuf bytes.Buffer
+	if err := s.runCmd(ctx, extract, pr, io.Discard, &errBuf); err != nil {
+		stderr := strings.TrimSpace(errBuf.String())
+		if stderr != "" {
+			return fmt.Errorf("upload dir %s -> %s: %w (%s)", source, destination, err, stderr)
+		}
+		return fmt.Errorf("upload dir %s -> %s: %w", source, destination, err)
+	}
+
+	if opts.Mode != "" {
+		chmod := fmt.Sprintf("chmod %s %s", shellQuote(opts.Mode), shellQuote(destination))
+		if opts.Sudo {
+			chmod = "sudo " + chmod
+		}
+		if _, err := s.Run(ctx, chmod, nil); err != nil {
+			return fmt.Errorf("chmod %s %s: %w", opts.Mode, destination, err)
+		}
+	}
+	return nil
+}
+
+// writeDirAsTar walks root and writes each entry to tw with paths relative
+// to root. Symlinks are preserved as-is; regular files are streamed. The
+// root entry itself is skipped — its contents become the archive top level.
+func writeDirAsTar(tw *tar.Writer, root string) error {
+	return filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if path == root {
+			return nil
+		}
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		info, err := d.Info()
+		if err != nil {
+			return err
+		}
+		var linkname string
+		if info.Mode()&os.ModeSymlink != 0 {
+			linkname, err = os.Readlink(path)
+			if err != nil {
+				return err
+			}
+		}
+		hdr, err := tar.FileInfoHeader(info, linkname)
+		if err != nil {
+			return err
+		}
+		hdr.Name = filepath.ToSlash(rel)
+		if d.IsDir() {
+			hdr.Name += "/"
+		}
+		if err := tw.WriteHeader(hdr); err != nil {
+			return err
+		}
+		if !info.Mode().IsRegular() {
+			return nil
+		}
+		f, err := os.Open(path)
+		if err != nil {
+			return err
+		}
+		_, copyErr := io.Copy(tw, f)
+		closeErr := f.Close()
+		if copyErr != nil {
+			return copyErr
+		}
+		return closeErr
+	})
 }
 
 // Close shuts down the underlying ssh client connection.

--- a/builder/proxmox/ssh_test.go
+++ b/builder/proxmox/ssh_test.go
@@ -596,6 +596,99 @@ func TestSSHRunner_UploadFile_DirectorySudo(t *testing.T) {
 	}
 }
 
+func TestSSHRunner_UploadFile_DirectoryMkdirFailure(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "x"), []byte("y"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	chain := &chainCmd{calls: []*fakeCmd{{err: errors.New("permission denied")}}}
+	r := &sshRunner{runCmd: chain.run}
+
+	err := r.UploadFile(context.Background(), root, "/root/dst", UploadOptions{})
+	if err == nil {
+		t.Fatal("expected mkdir failure to propagate")
+	}
+	if !strings.Contains(err.Error(), "mkdir /root/dst") {
+		t.Fatalf("expected mkdir error context, got %v", err)
+	}
+}
+
+func TestSSHRunner_UploadFile_DirectoryTarFailureIncludesStderr(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "x"), []byte("y"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	chain := &chainCmd{calls: []*fakeCmd{
+		{}, // mkdir ok
+		{err: errors.New("exit 2"), stderr: "tar: bad input\n"},
+	}}
+	r := &sshRunner{runCmd: chain.run}
+
+	err := r.UploadFile(context.Background(), root, "/opt/dst", UploadOptions{})
+	if err == nil {
+		t.Fatal("expected tar failure")
+	}
+	if !strings.Contains(err.Error(), "upload dir") || !strings.Contains(err.Error(), "tar: bad input") {
+		t.Fatalf("expected tar stderr in error, got %v", err)
+	}
+}
+
+func TestSSHRunner_UploadFile_DirectoryTarFailureBareWithoutStderr(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "x"), []byte("y"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	chain := &chainCmd{calls: []*fakeCmd{
+		{},
+		{err: errors.New("eof")},
+	}}
+	r := &sshRunner{runCmd: chain.run}
+
+	err := r.UploadFile(context.Background(), root, "/opt/dst", UploadOptions{})
+	if err == nil {
+		t.Fatal("expected tar failure")
+	}
+	if strings.Contains(err.Error(), "()") {
+		t.Fatalf("bare failure should omit empty parens, got %v", err)
+	}
+}
+
+func TestSSHRunner_UploadFile_DirectoryChmodFailure(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "x"), []byte("y"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	chain := &chainCmd{calls: []*fakeCmd{
+		{}, // mkdir
+		{}, // tar
+		{err: errors.New("operation not permitted")},
+	}}
+	r := &sshRunner{runCmd: chain.run}
+
+	err := r.UploadFile(context.Background(), root, "/opt/dst", UploadOptions{Mode: "0700"})
+	if err == nil {
+		t.Fatal("expected chmod failure")
+	}
+	if !strings.Contains(err.Error(), "chmod 0700 /opt/dst") {
+		t.Fatalf("expected chmod context, got %v", err)
+	}
+}
+
+func TestWriteDirAsTar_WalkErrorPropagates(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+	err := writeDirAsTar(tw, filepath.Join(t.TempDir(), "does-not-exist"))
+	_ = tw.Close()
+	if err == nil {
+		t.Fatal("expected walk error on missing root")
+	}
+}
+
 func TestWriteDirAsTar_PreservesSymlinkAsLink(t *testing.T) {
 	t.Parallel()
 	root := t.TempDir()

--- a/builder/proxmox/ssh_test.go
+++ b/builder/proxmox/ssh_test.go
@@ -23,6 +23,7 @@ THE SOFTWARE.
 package proxmox
 
 import (
+	"archive/tar"
 	"bytes"
 	"context"
 	"crypto/ed25519"
@@ -383,7 +384,7 @@ func TestSSHRunner_UploadFile_StreamsAndChmod(t *testing.T) {
 	chain := &chainCmd{calls: []*fakeCmd{{}, {}}}
 	r := &sshRunner{runCmd: chain.run}
 
-	if err := r.UploadFile(context.Background(), src, "/opt/dst", "0640"); err != nil {
+	if err := r.UploadFile(context.Background(), src, "/opt/dst", UploadOptions{Mode: "0640"}); err != nil {
 		t.Fatalf("UploadFile: %v", err)
 	}
 	if chain.idx != 2 {
@@ -410,7 +411,7 @@ func TestSSHRunner_UploadFile_NoModeSkipsChmod(t *testing.T) {
 	chain := &chainCmd{calls: []*fakeCmd{{}}}
 	r := &sshRunner{runCmd: chain.run}
 
-	if err := r.UploadFile(context.Background(), src, "/opt/dst", ""); err != nil {
+	if err := r.UploadFile(context.Background(), src, "/opt/dst", UploadOptions{}); err != nil {
 		t.Fatalf("UploadFile: %v", err)
 	}
 	if chain.idx != 1 {
@@ -421,12 +422,12 @@ func TestSSHRunner_UploadFile_NoModeSkipsChmod(t *testing.T) {
 func TestSSHRunner_UploadFile_MissingSourceWraps(t *testing.T) {
 	t.Parallel()
 	r := &sshRunner{runCmd: (&fakeCmd{}).run}
-	err := r.UploadFile(context.Background(), filepath.Join(t.TempDir(), "missing"), "/tmp/dst", "")
+	err := r.UploadFile(context.Background(), filepath.Join(t.TempDir(), "missing"), "/tmp/dst", UploadOptions{})
 	if err == nil {
 		t.Fatal("expected error opening missing source")
 	}
-	if !strings.Contains(err.Error(), "open source") {
-		t.Fatalf("expected open source error, got %v", err)
+	if !strings.Contains(err.Error(), "stat source") {
+		t.Fatalf("expected stat source error, got %v", err)
 	}
 }
 
@@ -442,7 +443,7 @@ func TestSSHRunner_UploadFile_CatFailureIncludesStderr(t *testing.T) {
 		stderr: "permission denied\n",
 	}}}
 	r := &sshRunner{runCmd: chain.run}
-	err := r.UploadFile(context.Background(), src, "/opt/dst", "0640")
+	err := r.UploadFile(context.Background(), src, "/opt/dst", UploadOptions{Mode: "0640"})
 	if err == nil {
 		t.Fatal("expected upload failure")
 	}
@@ -460,7 +461,7 @@ func TestSSHRunner_UploadFile_CatFailureBareWithoutStderr(t *testing.T) {
 	}
 	chain := &chainCmd{calls: []*fakeCmd{{err: errors.New("eof")}}}
 	r := &sshRunner{runCmd: chain.run}
-	err := r.UploadFile(context.Background(), src, "/opt/dst", "0640")
+	err := r.UploadFile(context.Background(), src, "/opt/dst", UploadOptions{Mode: "0640"})
 	if err == nil {
 		t.Fatal("expected upload failure")
 	}
@@ -481,12 +482,163 @@ func TestSSHRunner_UploadFile_ChmodFailureSurfaces(t *testing.T) {
 		{err: errors.New("operation not permitted")},
 	}}
 	r := &sshRunner{runCmd: chain.run}
-	err := r.UploadFile(context.Background(), src, "/opt/dst", "0640")
+	err := r.UploadFile(context.Background(), src, "/opt/dst", UploadOptions{Mode: "0640"})
 	if err == nil {
 		t.Fatal("expected chmod error to surface")
 	}
 	if !strings.Contains(err.Error(), "chmod 0640 /opt/dst") {
 		t.Fatalf("expected chmod context in error, got %v", err)
+	}
+}
+
+func TestSSHRunner_UploadFile_SudoUsesTeeAndSudoChmod(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src.txt")
+	if err := os.WriteFile(src, []byte("hi"), 0o600); err != nil {
+		t.Fatalf("write src: %v", err)
+	}
+	chain := &chainCmd{calls: []*fakeCmd{{}, {}}}
+	r := &sshRunner{runCmd: chain.run}
+
+	if err := r.UploadFile(context.Background(), src, "/root/dst", UploadOptions{Mode: "0600", Sudo: true}); err != nil {
+		t.Fatalf("UploadFile: %v", err)
+	}
+	if got := chain.calls[0].command; got != "sudo tee '/root/dst' >/dev/null" {
+		t.Fatalf("write command = %q, want sudo tee", got)
+	}
+	if got := chain.calls[1].command; got != "sudo chmod '0600' '/root/dst'" {
+		t.Fatalf("chmod command = %q, want sudo chmod", got)
+	}
+}
+
+func TestSSHRunner_UploadFile_DirectoryStreamsTar(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	// a/
+	//   b.txt  "hello"
+	//   c/
+	//     d.txt "world"
+	if err := os.MkdirAll(filepath.Join(root, "a", "c"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "a", "b.txt"), []byte("hello"), 0o644); err != nil {
+		t.Fatalf("write b: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "a", "c", "d.txt"), []byte("world"), 0o644); err != nil {
+		t.Fatalf("write d: %v", err)
+	}
+
+	chain := &chainCmd{calls: []*fakeCmd{{}, {}}}
+	r := &sshRunner{runCmd: chain.run}
+
+	src := filepath.Join(root, "a")
+	if err := r.UploadFile(context.Background(), src, "/opt/dst", UploadOptions{}); err != nil {
+		t.Fatalf("UploadFile dir: %v", err)
+	}
+	if chain.idx != 2 {
+		t.Fatalf("expected 2 commands (mkdir + tar), got %d", chain.idx)
+	}
+	if got := chain.calls[0].command; got != "mkdir -p '/opt/dst'" {
+		t.Fatalf("mkdir command = %q", got)
+	}
+	if got := chain.calls[1].command; got != "tar -C '/opt/dst' -xf -" {
+		t.Fatalf("tar command = %q", got)
+	}
+
+	tr := tar.NewReader(bytes.NewReader(chain.calls[1].stdinBuf))
+	entries := map[string]string{}
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("tar read: %v", err)
+		}
+		var body bytes.Buffer
+		if _, err := io.Copy(&body, tr); err != nil {
+			t.Fatalf("tar copy: %v", err)
+		}
+		entries[hdr.Name] = body.String()
+	}
+	if _, ok := entries["c/"]; !ok {
+		t.Errorf("expected c/ dir entry, got %v", entries)
+	}
+	if got := entries["b.txt"]; got != "hello" {
+		t.Errorf("b.txt = %q", got)
+	}
+	if got := entries["c/d.txt"]; got != "world" {
+		t.Errorf("c/d.txt = %q", got)
+	}
+}
+
+func TestSSHRunner_UploadFile_DirectorySudo(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "x"), []byte("y"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	chain := &chainCmd{calls: []*fakeCmd{{}, {}, {}}}
+	r := &sshRunner{runCmd: chain.run}
+
+	if err := r.UploadFile(context.Background(), root, "/root/dst", UploadOptions{Mode: "0700", Sudo: true}); err != nil {
+		t.Fatalf("UploadFile: %v", err)
+	}
+	if got := chain.calls[0].command; got != "sudo mkdir -p '/root/dst'" {
+		t.Fatalf("mkdir = %q", got)
+	}
+	if got := chain.calls[1].command; got != "sudo tar -C '/root/dst' -xf -" {
+		t.Fatalf("tar = %q", got)
+	}
+	if got := chain.calls[2].command; got != "sudo chmod '0700' '/root/dst'" {
+		t.Fatalf("chmod = %q", got)
+	}
+}
+
+func TestWriteDirAsTar_PreservesSymlinkAsLink(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	target := filepath.Join(root, "target.txt")
+	if err := os.WriteFile(target, []byte("t"), 0o644); err != nil {
+		t.Fatalf("write target: %v", err)
+	}
+	link := filepath.Join(root, "link.txt")
+	if err := os.Symlink("target.txt", link); err != nil {
+		t.Skipf("symlink unsupported: %v", err)
+	}
+
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+	if err := writeDirAsTar(tw, root); err != nil {
+		t.Fatalf("writeDirAsTar: %v", err)
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatalf("close tar: %v", err)
+	}
+
+	tr := tar.NewReader(&buf)
+	sawLink := false
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("tar read: %v", err)
+		}
+		if hdr.Name == "link.txt" {
+			sawLink = true
+			if hdr.Typeflag != tar.TypeSymlink {
+				t.Errorf("link.txt Typeflag = %v, want %v", hdr.Typeflag, tar.TypeSymlink)
+			}
+			if hdr.Linkname != "target.txt" {
+				t.Errorf("Linkname = %q, want target.txt", hdr.Linkname)
+			}
+		}
+	}
+	if !sawLink {
+		t.Error("symlink entry missing from archive")
 	}
 }
 

--- a/logging/logging.go
+++ b/logging/logging.go
@@ -126,9 +126,11 @@ func (l *CustomLogger) formatMessage(level LogLevel, message string, args ...int
 // shouldShowOnConsoleLocked determines if a message should be shown on console.
 // This method must be called while holding l.mu.
 // Logic:
-// - In quiet mode, only errors are shown
-// - In verbose mode, all messages are shown
-// - Otherwise, show messages at INFO level and above (INFO, WARN, ERROR)
+//   - In quiet mode, only errors are shown
+//   - In verbose mode, all messages are shown
+//   - Otherwise, the configured LogLevel acts as a floor: messages at that
+//     level or higher pass through. So --log-level=debug shows DEBUG, while
+//     --log-level=warn hides INFO.
 func (l *CustomLogger) shouldShowOnConsoleLocked(level LogLevel) bool {
 	// In quiet mode, only show errors
 	if l.Quiet {
@@ -140,8 +142,22 @@ func (l *CustomLogger) shouldShowOnConsoleLocked(level LogLevel) bool {
 		return true
 	}
 
-	// Default: show INFO and above (INFO, WARN, ERROR but not DEBUG)
-	return level >= InfoLevel
+	return level >= logLevelFromSlog(l.LogLevel)
+}
+
+// logLevelFromSlog translates the slog.Level threshold stored on the logger
+// back into the local LogLevel scale used for filtering.
+func logLevelFromSlog(level slog.Level) LogLevel {
+	switch {
+	case level <= slog.LevelDebug:
+		return DebugLevel
+	case level <= slog.LevelInfo:
+		return InfoLevel
+	case level <= slog.LevelWarn:
+		return WarnLevel
+	default:
+		return ErrorLevel
+	}
 }
 
 func (l *CustomLogger) log(level LogLevel, message string, args ...interface{}) {

--- a/logging/logging_test.go
+++ b/logging/logging_test.go
@@ -575,22 +575,52 @@ func TestCustomLogger_VerboseMode_ShowsDebug(t *testing.T) {
 }
 
 func TestCustomLogger_DefaultMode_HidesDebug(t *testing.T) {
-	// Default mode (not verbose, not quiet) should hide debug messages
+	// At the default LogLevel (Info) with neither verbose nor quiet,
+	// DEBUG messages are filtered out and INFO+ pass through.
 	buf := &bytes.Buffer{}
-	logger := logging.NewCustomLogger(slog.LevelDebug)
+	logger := logging.NewCustomLogger(slog.LevelInfo)
 	logger.ConsoleWriter = buf
-	// Default: verbose=false, quiet=false
 
 	logger.Debug("debug should be hidden")
 	output := buf.String()
 	if output != "" {
-		t.Errorf("expected debug to be hidden in default mode, got %q", output)
+		t.Errorf("expected debug to be hidden at info level, got %q", output)
 	}
 
 	logger.Info("info should appear")
 	output = buf.String()
 	if !bytes.Contains(buf.Bytes(), []byte("info should appear")) {
-		t.Errorf("expected info to appear in default mode, got %q", output)
+		t.Errorf("expected info to appear at info level, got %q", output)
+	}
+}
+
+func TestCustomLogger_DebugLevel_ShowsDebugWithoutVerbose(t *testing.T) {
+	// --log-level=debug should surface DEBUG without requiring --verbose.
+	buf := &bytes.Buffer{}
+	logger := logging.NewCustomLogger(slog.LevelDebug)
+	logger.ConsoleWriter = buf
+
+	logger.Debug("debug should appear at debug level")
+	if !bytes.Contains(buf.Bytes(), []byte("debug should appear at debug level")) {
+		t.Errorf("expected debug to appear at debug level without verbose, got %q", buf.String())
+	}
+}
+
+func TestCustomLogger_WarnLevel_HidesInfo(t *testing.T) {
+	// --log-level=warn should suppress INFO and DEBUG.
+	buf := &bytes.Buffer{}
+	logger := logging.NewCustomLogger(slog.LevelWarn)
+	logger.ConsoleWriter = buf
+
+	logger.Info("info should be hidden")
+	logger.Debug("debug should be hidden")
+	if buf.Len() != 0 {
+		t.Errorf("expected no output at warn level for info/debug, got %q", buf.String())
+	}
+
+	logger.Warn("warn should appear")
+	if !bytes.Contains(buf.Bytes(), []byte("warn should appear")) {
+		t.Errorf("expected warn to appear at warn level, got %q", buf.String())
 	}
 }
 

--- a/schema/warpgate-template.json
+++ b/schema/warpgate-template.json
@@ -503,6 +503,10 @@
         "user": {
           "type": "string",
           "description": "User specifies which user to run the provisioner as"
+        },
+        "sudo": {
+          "type": "boolean",
+          "description": "Sudo elevates privileges when running shell/file/script provisioners over SSH.\nOnly meaningful for Linux Proxmox builds where the SSH user has NOPASSWD sudo;\nother backends ignore it. When combined with User the User wrap takes precedence."
         }
       },
       "additionalProperties": false,


### PR DESCRIPTION
**Key Changes:**

- Added a sudo provisioner option for Proxmox SSH shell, file, and script workflows
- Extended SSH uploads to handle directories through tar streaming while preserving symlinks
- Improved provisioner diagnostics by surfacing failed remote output at warn level
- Fixed console log filtering so configured log levels are honored without requiring verbose mode

**Added:**

- Sudo provisioner configuration - Introduced a boolean sudo field in the provisioner model and JSON schema for elevated SSH-based provisioning
- Upload options support - Added UploadOptions to carry mode and sudo behavior through SSH upload operations
- Directory upload support - Added tar-based recursive directory uploads with destination creation, optional chmod, and symlink preservation
- Test coverage - Added tests for sudo shell/file/script behavior, directory upload tar contents, symlink preservation, and log-level filtering

**Changed:**

- SSH upload behavior - Updated UploadFile to detect source type, stream regular files via cat or sudo tee, and stream directories via remote tar extraction
- Provisioner execution - Applied sudo wrapping for shell and script execution while preserving User precedence when both user and sudo are set
- Provisioner output logging - Routes failed shell/script output to warn level so diagnostics remain visible, while successful output stays debug-only
- Console log filtering - Uses the configured slog level as the display threshold so debug and warn levels behave consistently without verbose mode