### PR TITLE
fix: preserve newlines in proxmox shell provisioners

### DIFF
--- a/builder/proxmox/provisioners.go
+++ b/builder/proxmox/provisioners.go
@@ -120,17 +120,20 @@ func runShellProvisioner(ctx context.Context, runner SSHRunner, p builder.Provis
 	}
 	cmd := strings.Join(append([]string{"set -e"}, p.Inline...), "\n")
 	if p.WorkingDir != "" {
-		cmd = fmt.Sprintf("cd %q && %s", p.WorkingDir, cmd)
+		cmd = fmt.Sprintf("cd %s && %s", shellQuote(p.WorkingDir), cmd)
 	}
 	switch {
 	case p.User != "":
 		// Use sudo -u so env vars propagate correctly via sudo -E. When
 		// both User and Sudo are set, this wrap already elevates so we
-		// skip the plain sudo wrap below.
-		cmd = fmt.Sprintf("sudo -E -u %s -- sh -c %q", p.User, cmd)
+		// skip the plain sudo wrap below. shellQuote (single-quote style)
+		// preserves literal newlines inside the wrapped script; Go's %q
+		// would escape them as the two-char sequence `\n`, which `sh -c`
+		// does not unescape inside its double-quoted argument.
+		cmd = fmt.Sprintf("sudo -E -u %s -- sh -c %s", p.User, shellQuote(cmd))
 	case p.Sudo:
 		// sudo -E preserves env exports emitted by withEnvExports.
-		cmd = fmt.Sprintf("sudo -E sh -c %q", cmd)
+		cmd = fmt.Sprintf("sudo -E sh -c %s", shellQuote(cmd))
 	}
 	out, err := runner.Run(ctx, cmd, p.Environment)
 	logProvisionerOutput(ctx, "shell", out, err)

--- a/builder/proxmox/provisioners_test.go
+++ b/builder/proxmox/provisioners_test.go
@@ -195,6 +195,50 @@ func TestRunProvisioners_ShellWithSudo(t *testing.T) {
 	}
 }
 
+// Multi-line inline scripts wrapped with `sudo` must preserve literal
+// newlines so the remote `sh -c` parses them as separate statements. Go's
+// %q would emit the two-char sequence `\n` which `sh` does not unescape
+// inside its argument, producing exit 2 ("Syntax error") on the remote.
+func TestRunProvisioners_ShellSudoPreservesNewlines(t *testing.T) {
+	t.Parallel()
+	r := &fakeRunner{}
+	err := runProvisioners(context.Background(), r, []builder.Provisioner{{
+		Type:   "shell",
+		Inline: []string{"echo one", "echo two", "echo three"},
+		Sudo:   true,
+	}})
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	got := r.commands[0]
+	if !strings.Contains(got, "\necho one\n") || !strings.Contains(got, "\necho two\n") || !strings.Contains(got, "\necho three") {
+		t.Fatalf("expected each inline command on its own line, got %q", got)
+	}
+	if strings.Contains(got, `\necho one`) {
+		t.Fatalf("sudo wrap escaped newlines as \\n (Go %%q quoting bug), got %q", got)
+	}
+}
+
+func TestRunProvisioners_ShellUserSudoPreservesNewlines(t *testing.T) {
+	t.Parallel()
+	r := &fakeRunner{}
+	err := runProvisioners(context.Background(), r, []builder.Provisioner{{
+		Type:   "shell",
+		Inline: []string{"echo one", "echo two"},
+		User:   "kali",
+	}})
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	got := r.commands[0]
+	if !strings.Contains(got, "\necho one\n") || !strings.Contains(got, "\necho two") {
+		t.Fatalf("expected each inline command on its own line, got %q", got)
+	}
+	if strings.Contains(got, `\necho one`) {
+		t.Fatalf("user wrap escaped newlines as \\n, got %q", got)
+	}
+}
+
 func TestRunProvisioners_ShellUserBeatsSudo(t *testing.T) {
 	t.Parallel()
 	r := &fakeRunner{}


### PR DESCRIPTION
**Key Changes:**

- Fixed sudo-wrapped shell provisioners so multi-line inline scripts remain valid remote shell input
- Replaced Go string quoting with shell-safe quoting for `sh -c` command wrapping
- Covered sudo and user execution paths with regression tests for newline preservation

**Added:**

- Regression coverage for multi-line shell scripts executed through sudo and user wrappers - verifies inline commands remain separated by literal newlines and are not escaped as `\n` sequences

**Changed:**

- Shell provisioner command wrapping - switched working directory, sudo, and user execution quoting to `shellQuote` so remote `sh -c` receives the intended script content instead of Go-escaped strings
- User execution comments - clarified why single-quote style shell quoting is required to avoid syntax errors from escaped newlines in multi-line inline scripts