### PR TITLE
build: update go toolchain to 1.26.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cowdogmoo/warpgate/v3
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.21.1


### PR DESCRIPTION
**Key Changes:**

- Updated the module Go version from 1.26.3 to 1.26.4
- Aligns project build metadata with the latest Go patch release
- Keeps dependencies unchanged, limiting the scope to the toolchain version

**Changed:**

- Go toolchain version - Updated the `go` directive in `go.mod` to use Go 1.26.4 while leaving all required modules unchanged