### PR TITLE
fix: prevent broken copier dependency upgrades

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -89,6 +89,13 @@
       ],
       groupName: 'go indirect dependencies',
     },
+    {
+      description: 'Pin jinzhu/copier — go-proxmox v0.7.1 requires v0.3.4; v0.4.0 breaks Task deep-copy (nil-pointer panic in TestLiveRunner_StopAndTemplate)',
+      matchPackageNames: [
+        'github.com/jinzhu/copier',
+      ],
+      enabled: false,
+    },
   ],
   lockFileMaintenance: {
     enabled: true,


### PR DESCRIPTION
**Key Changes:**

- Disabled Renovate updates for `github.com/jinzhu/copier` to avoid upgrading past the compatible version
- Documented the compatibility constraint with `go-proxmox v0.7.1`, which requires `copier v0.3.4`
- Prevented `copier v0.4.0` from triggering a Task deep-copy nil-pointer panic in `TestLiveRunner_StopAndTemplate`

**Added:**

- Renovate package rule for `github.com/jinzhu/copier` - Pins the dependency update behavior by disabling Renovate upgrades until the upstream compatibility issue is resolved