### PR TITLE
chore: simplify renovate go module update rules and remove merge-queue strategy

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -58,48 +58,20 @@
       ],
       automerge: true,
       automergeType: 'pr',
-      automergeStrategy: 'merge-queue',
     },
     {
-      description: 'Auto merge Go dependency updates (patch and digest)',
+      description: 'Collapse all non-major Go module updates (direct + indirect, including 0.x minors) into a single auto-merging PR. One branch touching go.mod means Renovate PRs cannot conflict with each other; majors are intentionally excluded so they get individual review.',
       matchManagers: [
         'gomod',
-      ],
-      matchUpdateTypes: [
-        'patch',
-        'digest',
-      ],
-      automerge: true,
-      automergeType: 'pr',
-      automergeStrategy: 'merge-queue',
-    },
-    {
-      description: 'Auto merge stable (>= 1.0.0) Go minor updates',
-      matchManagers: [
-        'gomod',
-      ],
-      matchCurrentVersion: '>= 1.0.0',
-      matchUpdateTypes: [
-        'minor',
-      ],
-      automerge: true,
-      automergeType: 'pr',
-      automergeStrategy: 'merge-queue',
-    },
-    {
-      description: 'Group Go indirect dependencies (non-major)',
-      matchManagers: [
-        'gomod',
-      ],
-      matchDepTypes: [
-        'indirect',
       ],
       matchUpdateTypes: [
         'minor',
         'patch',
         'digest',
       ],
-      groupName: 'go indirect dependencies',
+      groupName: 'go modules',
+      automerge: true,
+      automergeType: 'pr',
     },
     {
       description: 'Pin jinzhu/copier — go-proxmox v0.7.1 requires v0.3.4; v0.4.0 breaks Task deep-copy (nil-pointer panic in TestLiveRunner_StopAndTemplate)',
@@ -113,6 +85,5 @@
     enabled: true,
     automerge: true,
     automergeType: 'pr',
-    automergeStrategy: 'merge-queue',
   },
 }


### PR DESCRIPTION
**Key Changes:**

- Consolidated multiple Go module update rules into a single grouped rule covering minor, patch, and digest updates
- Removed `automergeStrategy: 'merge-queue'` from all Renovate rules across the config
- Eliminated the separate rules for stable minor updates and indirect dependency grouping, reducing config complexity

**Changed:**

- Go module update strategy - Merged the separate patch/digest, stable minor, and indirect dependency rules into one unified rule that groups all non-major Go module updates (direct and indirect, including 0.x minors) into a single auto-merging PR under the group name `go modules`, preventing branch conflicts caused by multiple concurrent PRs touching `go.mod`

**Removed:**

- `automergeStrategy: 'merge-queue'` - Removed from all package rules and the global config block, as it is no longer needed
- Separate Go minor update rule - Eliminated the dedicated rule matching `matchCurrentVersion: '>= 1.0.0'` for minor updates, as this is now covered by the consolidated rule
- Separate indirect dependency grouping rule - Removed the `go indirect dependencies` group rule, folding indirect updates into the new unified `go modules` group