### PR TITLE
ci: stop gating pre-commit job on hook autoupdate

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -102,4 +102,4 @@ jobs:
 
       - name: Run pre-commit
         run: |
-          task -y pre-commit:run-pre-commit
+          task -y pre-commit:run-hooks


### PR DESCRIPTION
**Key Changes:**

- Switched the pre-commit CI job from `task pre-commit:run-pre-commit` to `task pre-commit:run-hooks`, so the job runs the hooks without first running `pre-commit autoupdate`
- Relies on Renovate, which already manages pre-commit hook versions here, to surface hook bumps as reviewable PRs instead of mutating config inside CI

**Changed:**

- Pre-commit workflow - Updated the `Run pre-commit` step in `.github/workflows/pre-commit.yaml` to call `pre-commit:run-hooks`