### PR TITLE
fix: replace bare exit 194 with native AWSTOE reboot action steps

### DIFF
--- a/builder/ami/component.go
+++ b/builder/ami/component.go
@@ -205,7 +205,16 @@ func (g *ComponentGenerator) createFileComponent(provisioner builder.Provisioner
 	return marshalComponentDocument(doc)
 }
 
-// createShellComponent creates a component document for shell provisioner
+// createShellComponent creates a component document for shell provisioner.
+//
+// A bare `exit 194` in the inline commands is AWS Image Builder's documented
+// request to reboot and resume at the next step. Emitting it as the last
+// command of an ExecuteBash step is unsafe: the reboot tears down the SSM
+// RunCommand that AWSTOE is using to execute the step, so the managed build
+// workflow's ApplyBuildComponents wait either hangs (the invocation vanishes)
+// or fails. Instead we strip the marker and emit a dedicated AWSTOE Reboot
+// action step, letting AWSTOE own the reboot/resume handshake and resume the
+// component at the following step. See buildShellSteps.
 func (g *ComponentGenerator) createShellComponent(provisioner builder.Provisioner) (string, error) {
 	if len(provisioner.Inline) == 0 {
 		return "", fmt.Errorf("shell provisioner has no inline commands")
@@ -213,35 +222,88 @@ func (g *ComponentGenerator) createShellComponent(provisioner builder.Provisione
 
 	commands := append([]string{}, provisioner.Inline...)
 
+	if len(provisioner.Environment) > 0 {
+		envVars := make([]string, 0, len(provisioner.Environment))
+		for key, value := range provisioner.Environment {
+			envVars = append(envVars, fmt.Sprintf("export %s='%s'", key, shellEscapeSingleQuote(value)))
+		}
+		commands = append(envVars, commands...)
+	}
+
 	doc := map[string]interface{}{
 		"schemaVersion": 1.0,
 		"name":          "ShellProvisioner",
 		"description":   "Shell provisioner component",
 		"phases": []map[string]interface{}{
 			{
-				"name": "build",
-				"steps": []map[string]interface{}{
-					{
-						"name":   "ExecuteShellCommands",
-						"action": "ExecuteBash",
-						"inputs": map[string]interface{}{
-							"commands": commands,
-						},
-					},
-				},
+				"name":  "build",
+				"steps": buildShellSteps(commands),
 			},
 		},
 	}
 
-	if len(provisioner.Environment) > 0 {
-		envVars := make([]string, 0, len(provisioner.Environment))
-		for key, value := range provisioner.Environment {
-			envVars = append(envVars, fmt.Sprintf("export %s='%s'", key, shellEscapeSingleQuote(value)))
+	return marshalComponentDocument(doc)
+}
+
+// buildShellSteps splits a flat shell command list into AWSTOE steps. Each run
+// of ordinary commands becomes an ExecuteBash step; every `exit 194` reboot
+// marker is removed and replaced with a native AWSTOE Reboot action step so
+// AWSTOE persists state, reboots, and resumes at the following step instead of
+// the SSM RunCommand being killed mid-invocation. The common case (no reboot
+// marker) yields a single ExecuteShellCommands step, identical to the prior
+// behavior.
+func buildShellSteps(commands []string) []map[string]interface{} {
+	steps := []map[string]interface{}{}
+	var current []string
+	execCount := 0
+	rebootCount := 0
+
+	flush := func() {
+		if len(current) == 0 {
+			return
 		}
-		doc["phases"].([]map[string]interface{})[0]["steps"].([]map[string]interface{})[0]["inputs"].(map[string]interface{})["commands"] = append(envVars, commands...)
+		name := "ExecuteShellCommands"
+		if execCount > 0 {
+			name = fmt.Sprintf("ExecuteShellCommands_%d", execCount)
+		}
+		steps = append(steps, map[string]interface{}{
+			"name":   name,
+			"action": "ExecuteBash",
+			"inputs": map[string]interface{}{
+				"commands": current,
+			},
+		})
+		execCount++
+		current = nil
 	}
 
-	return marshalComponentDocument(doc)
+	for _, cmd := range commands {
+		if isShellRebootSignal(cmd) {
+			flush()
+			steps = append(steps, map[string]interface{}{
+				"name":   fmt.Sprintf("RebootAfterShellCommands_%d", rebootCount),
+				"action": "Reboot",
+				"inputs": map[string]interface{}{
+					"delaySeconds": 0,
+				},
+			})
+			rebootCount++
+			continue
+		}
+		current = append(current, cmd)
+	}
+	flush()
+
+	return steps
+}
+
+// isShellRebootSignal reports whether a single shell command is a bare
+// `exit 194` — AWS Image Builder's documented reboot-and-resume request.
+// Surrounding whitespace is tolerated; anything else (for example an echo that
+// merely mentions 194) is left untouched.
+func isShellRebootSignal(cmd string) bool {
+	fields := strings.Fields(cmd)
+	return len(fields) == 2 && fields[0] == "exit" && fields[1] == "194"
 }
 
 // createScriptComponent creates a component document for script provisioner

--- a/builder/ami/component_test.go
+++ b/builder/ami/component_test.go
@@ -37,7 +37,31 @@ import (
 	"github.com/cowdogmoo/warpgate/v3/builder"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
 )
+
+// parsedComponent is a minimal view of a generated AWSTOE component document,
+// used by tests to assert step structure without string-scraping YAML.
+type parsedComponent struct {
+	Phases []struct {
+		Name  string `yaml:"name"`
+		Steps []struct {
+			Name   string `yaml:"name"`
+			Action string `yaml:"action"`
+			Inputs struct {
+				Commands []string `yaml:"commands"`
+			} `yaml:"inputs"`
+		} `yaml:"steps"`
+	} `yaml:"phases"`
+}
+
+func parseComponentDoc(t *testing.T, doc string) parsedComponent {
+	t.Helper()
+	var pc parsedComponent
+	require.NoError(t, yaml.Unmarshal([]byte(doc), &pc))
+	require.Len(t, pc.Phases, 1)
+	return pc
+}
 
 func TestNewComponentGenerator(t *testing.T) {
 	t.Parallel()
@@ -597,6 +621,133 @@ func TestShellComponent_WithEnvironmentSpecialChars(t *testing.T) {
 	assert.Contains(t, doc, "export GREETING='it'\\''s a test'")
 	// Command substitution should be safely quoted (single quotes prevent expansion)
 	assert.Contains(t, doc, "export CMD='$(whoami)'")
+}
+
+func TestShellComponent_NoReboot_SingleStep(t *testing.T) {
+	t.Parallel()
+	gen := &ComponentGenerator{}
+	provisioner := builder.Provisioner{
+		Type:   "shell",
+		Inline: []string{"apt-get update", "apt-get install -y nginx"},
+	}
+
+	doc, err := gen.createShellComponent(provisioner)
+	require.NoError(t, err)
+
+	pc := parseComponentDoc(t, doc)
+	require.Len(t, pc.Phases[0].Steps, 1)
+	step := pc.Phases[0].Steps[0]
+	assert.Equal(t, "ExecuteShellCommands", step.Name)
+	assert.Equal(t, "ExecuteBash", step.Action)
+	assert.Equal(t, []string{"apt-get update", "apt-get install -y nginx"}, step.Inputs.Commands)
+}
+
+// TestShellComponent_TrailingRebootSignal is the regression test for the NVIDIA
+// driver build hang: a provisioner that ends with a bare `exit 194` must emit a
+// dedicated native Reboot action step rather than embedding the exit code in the
+// ExecuteBash command list.
+func TestShellComponent_TrailingRebootSignal(t *testing.T) {
+	t.Parallel()
+	gen := &ComponentGenerator{}
+	provisioner := builder.Provisioner{
+		Type: "shell",
+		Inline: []string{
+			"apt-get install -y nvidia-driver",
+			"dkms status",
+			`echo "requesting Image Builder reboot (exit 194)"`,
+			"exit 194",
+		},
+	}
+
+	doc, err := gen.createShellComponent(provisioner)
+	require.NoError(t, err)
+
+	pc := parseComponentDoc(t, doc)
+	steps := pc.Phases[0].Steps
+	require.Len(t, steps, 2)
+
+	assert.Equal(t, "ExecuteBash", steps[0].Action)
+	assert.Equal(t, "ExecuteShellCommands", steps[0].Name)
+	// The bare exit 194 must be stripped; the echo that mentions it stays.
+	assert.NotContains(t, steps[0].Inputs.Commands, "exit 194")
+	assert.Contains(t, steps[0].Inputs.Commands, `echo "requesting Image Builder reboot (exit 194)"`)
+
+	assert.Equal(t, "Reboot", steps[1].Action)
+	assert.Equal(t, "RebootAfterShellCommands_0", steps[1].Name)
+	// No raw exit 194 anywhere in the rendered document.
+	assert.NotContains(t, doc, "- exit 194")
+}
+
+func TestShellComponent_RebootInMiddle_SplitsSteps(t *testing.T) {
+	t.Parallel()
+	gen := &ComponentGenerator{}
+	provisioner := builder.Provisioner{
+		Type: "shell",
+		Inline: []string{
+			"install-driver",
+			"exit 194",
+			"validate-driver",
+		},
+	}
+
+	doc, err := gen.createShellComponent(provisioner)
+	require.NoError(t, err)
+
+	steps := parseComponentDoc(t, doc).Phases[0].Steps
+	require.Len(t, steps, 3)
+
+	assert.Equal(t, "ExecuteBash", steps[0].Action)
+	assert.Equal(t, "ExecuteShellCommands", steps[0].Name)
+	assert.Equal(t, []string{"install-driver"}, steps[0].Inputs.Commands)
+
+	assert.Equal(t, "Reboot", steps[1].Action)
+
+	// AWSTOE resumes at the next step after the reboot.
+	assert.Equal(t, "ExecuteBash", steps[2].Action)
+	assert.Equal(t, "ExecuteShellCommands_1", steps[2].Name)
+	assert.Equal(t, []string{"validate-driver"}, steps[2].Inputs.Commands)
+}
+
+func TestShellComponent_EnvVarsPrecedeReboot(t *testing.T) {
+	t.Parallel()
+	gen := &ComponentGenerator{}
+	provisioner := builder.Provisioner{
+		Type:        "shell",
+		Inline:      []string{"install-driver", "exit 194"},
+		Environment: map[string]string{"FOO": "bar"},
+	}
+
+	doc, err := gen.createShellComponent(provisioner)
+	require.NoError(t, err)
+
+	steps := parseComponentDoc(t, doc).Phases[0].Steps
+	require.Len(t, steps, 2)
+	// Env exports land in the first (pre-reboot) ExecuteBash step.
+	assert.Contains(t, steps[0].Inputs.Commands, "export FOO='bar'")
+	assert.Equal(t, "Reboot", steps[1].Action)
+}
+
+func TestIsShellRebootSignal(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		cmd  string
+		want bool
+	}{
+		{name: "bare exit 194", cmd: "exit 194", want: true},
+		{name: "leading and trailing whitespace", cmd: "  exit 194  ", want: true},
+		{name: "extra internal whitespace", cmd: "exit   194", want: true},
+		{name: "echo mentioning 194", cmd: `echo "requesting reboot (exit 194)"`, want: false},
+		{name: "different exit code", cmd: "exit 1", want: false},
+		{name: "exit 194 with trailing comment", cmd: "exit 194 # reboot", want: false},
+		{name: "unrelated command", cmd: "apt-get update", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, isShellRebootSignal(tt.cmd))
+		})
+	}
 }
 
 func TestGetComponentARN_Success(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization/v2 v2.2.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v8 v8.1.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources/v3 v3.0.1
-	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources/v4 v4.0.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/virtualmachineimagebuilder/armvirtualmachineimagebuilder/v3 v3.0.0
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.8.0
 	github.com/Masterminds/semver/v3 v3.5.0

--- a/go.sum
+++ b/go.sum
@@ -20,7 +20,6 @@ github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armdeployments v
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armdeployments v1.0.0/go.mod h1:fewgRjNVE84QVVh798sIMFb7gPXPp7NmnekGnboSnXk=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources/v3 v3.0.1 h1:guyQA4b8XB2sbJZXzUnOF9mn0WDBv/ZT7me9wTipKtE=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources/v3 v3.0.1/go.mod h1:8h8yhzh9o+0HeSIhUxYny+rEQajScrfIpNktvgYG3Q8=
-github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources/v4 v4.0.0/go.mod h1:IJLGVEPS/CqR2k0Q+EzmHqus1F69g5TCYzLFSWUM0Yw=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage v1.8.1 h1:/Zt+cDPnpC3OVDm/JKLOs7M2DKmLRIIp3XIx9pHHiig=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage v1.8.1/go.mod h1:Ng3urmn6dYe8gnbCMoHHVl5APYz2txho3koEkV2o2HA=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/virtualmachineimagebuilder/armvirtualmachineimagebuilder/v3 v3.0.0 h1:FiTxlBPVRE37u6+cj5hGdpkQ8+iOf6KlL2QXjHYQZ8w=


### PR DESCRIPTION
**Key Changes:**

- Fixed a build hang caused by embedding `exit 194` reboot markers inside `ExecuteBash` steps, where the SSM RunCommand teardown during reboot caused the managed workflow to hang or fail
- Introduced `buildShellSteps` to split a flat command list into alternating `ExecuteBash` and native `Reboot` action steps, letting AWSTOE own the reboot/resume handshake
- Environment variable exports are now prepended before step splitting, ensuring they appear in the correct pre-reboot `ExecuteBash` step
- Removed the unused `armresources/v4` dependency from `go.mod` and `go.sum`

**Added:**

- `buildShellSteps` function - splits shell commands into AWSTOE steps, replacing each bare `exit 194` with a dedicated `Reboot` action step (`RebootAfterShellCommands_N`) and grouping surrounding commands into sequentially named `ExecuteBash` steps (`ExecuteShellCommands`, `ExecuteShellCommands_1`, etc.)
- `isShellRebootSignal` helper - detects bare `exit 194` tokens with whitespace tolerance, leaving any command that merely mentions `194` (e.g. an echo) untouched
- `parsedComponent` test struct and `parseComponentDoc` helper - enables structural YAML assertion in tests without fragile string scraping
- Comprehensive test coverage for the new reboot-splitting logic: `TestShellComponent_NoReboot_SingleStep`, `TestShellComponent_TrailingRebootSignal`, `TestShellComponent_RebootInMiddle_SplitsSteps`, `TestShellComponent_EnvVarsPrecedeReboot`, and `TestIsShellRebootSignal`

**Changed:**

- `createShellComponent` - environment variable injection now happens before `buildShellSteps` is called so exports are prepended to the full command slice prior to splitting; the inline step construction is delegated entirely to `buildShellSteps` rather than being inlined in the document literal
- Extended `createShellComponent` doc comment to explain why bare `exit 194` in `ExecuteBash` is unsafe and how the new approach resolves it

**Removed:**

- Hardcoded single-step `ExecuteShellCommands` construction inside `createShellComponent` - replaced by the generalized `buildShellSteps` function
- `armresources/v4` Azure SDK dependency - removed from `go.mod` and `go.sum` as it was unused