### PR TITLE
build: upgrade armresources dependency from v3 to v4

### DIFF
--- a/builder/azure/discover.go
+++ b/builder/azure/discover.go
@@ -31,7 +31,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v8"
-	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources/v3"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources/v4"
 	"github.com/cowdogmoo/warpgate/v3/builder"
 	"github.com/cowdogmoo/warpgate/v3/logging"
 )

--- a/builder/azure/pipeline_test.go
+++ b/builder/azure/pipeline_test.go
@@ -33,7 +33,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v8"
-	armresources "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources/v3"
+	armresources "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources/v4"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/virtualmachineimagebuilder/armvirtualmachineimagebuilder/v3"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -560,7 +560,8 @@ func TestGalleryImagesAdapter_ListImageDefs_Error(t *testing.T) {
 // TestResourcesAdapter_ListByResourceGroup_Success exercises the ARM resources pager.
 func TestResourcesAdapter_ListByResourceGroup_Success(t *testing.T) {
 	s := newAzTestServer(t)
-	s.register("/subscriptions/sub-1/resourceGroups/rg-1/resources", 200, `{
+	// armresources v4 requests lowercase "resourcegroups" for this operation.
+	s.register("/subscriptions/sub-1/resourcegroups/rg-1/resources", 200, `{
 		"value":[
 			{
 				"id":"/subscriptions/sub-1/resourceGroups/rg-1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/my-uami",
@@ -585,7 +586,7 @@ func TestResourcesAdapter_ListByResourceGroup_Success(t *testing.T) {
 // TestResourcesAdapter_ListByResourceGroup_Error propagates SDK errors.
 func TestResourcesAdapter_ListByResourceGroup_Error(t *testing.T) {
 	s := newAzTestServer(t)
-	s.register("/subscriptions/sub-1/resourceGroups/rg-1/resources", 401,
+	s.register("/subscriptions/sub-1/resourcegroups/rg-1/resources", 401,
 		`{"error":{"code":"Unauthorized","message":"access denied"}}`)
 
 	rc := s.resourcesClient(t)

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.14.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization/v2 v2.2.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v8 v8.1.0
-	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources/v3 v3.0.1
+	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources/v4 v4.0.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/virtualmachineimagebuilder/armvirtualmachineimagebuilder/v3 v3.0.0
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.8.0
 	github.com/Masterminds/semver/v3 v3.5.0

--- a/go.sum
+++ b/go.sum
@@ -20,6 +20,8 @@ github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armdeployments v
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armdeployments v1.0.0/go.mod h1:fewgRjNVE84QVVh798sIMFb7gPXPp7NmnekGnboSnXk=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources/v3 v3.0.1 h1:guyQA4b8XB2sbJZXzUnOF9mn0WDBv/ZT7me9wTipKtE=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources/v3 v3.0.1/go.mod h1:8h8yhzh9o+0HeSIhUxYny+rEQajScrfIpNktvgYG3Q8=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources/v4 v4.0.0 h1:LXGvNeGX6VLx1S+wk3bbWrYWZuVow84Mny4T1I0CgBw=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources/v4 v4.0.0/go.mod h1:IJLGVEPS/CqR2k0Q+EzmHqus1F69g5TCYzLFSWUM0Yw=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage v1.8.1 h1:/Zt+cDPnpC3OVDm/JKLOs7M2DKmLRIIp3XIx9pHHiig=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage v1.8.1/go.mod h1:Ng3urmn6dYe8gnbCMoHHVl5APYz2txho3koEkV2o2HA=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/virtualmachineimagebuilder/armvirtualmachineimagebuilder/v3 v3.0.0 h1:FiTxlBPVRE37u6+cj5hGdpkQ8+iOf6KlL2QXjHYQZ8w=


### PR DESCRIPTION
**Key Changes:**

- Upgraded `armresources` SDK from v3.0.1 to v4.0.0 across all import sites
- Updated test URL paths to match v4's lowercase `resourcegroups` path segment behavior
- Updated `go.mod` and `go.sum` to reflect the new dependency version

**Changed:**

- ARM resources SDK version - Updated import paths from `armresources/v3` to `armresources/v4` in `builder/azure/discover.go` and `builder/azure/pipeline_test.go`, and bumped the module requirement in `go.mod` from `v3.0.1` to `v4.0.0`
- Test route registration - Adjusted mock server paths in `pipeline_test.go` from `/resourceGroups/` to `/resourcegroups/` to align with the URL casing change introduced in armresources v4