### PR TITLE
chore: skip major updates for indirect go modules in renovate config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -74,6 +74,19 @@
       automergeType: 'pr',
     },
     {
+      description: 'Skip major updates for indirect Go modules — a v2+ major changes the import path, so the bump cannot take effect until a direct dependent imports the new path; go mod tidy strips the requirement and the PR always fails the go-mod-tidy hook (see #1957)',
+      matchManagers: [
+        'gomod',
+      ],
+      matchDepTypes: [
+        'indirect',
+      ],
+      matchUpdateTypes: [
+        'major',
+      ],
+      enabled: false,
+    },
+    {
       description: 'Pin jinzhu/copier — go-proxmox v0.7.1 requires v0.3.4; v0.4.0 breaks Task deep-copy (nil-pointer panic in TestLiveRunner_StopAndTemplate)',
       matchPackageNames: [
         'github.com/jinzhu/copier',


### PR DESCRIPTION
**Key Changes:**

- Disabled automatic major version updates for indirect Go module dependencies to prevent consistently failing PRs
- Added explanatory comment referencing issue #1957 to document the reasoning behind the rule
- Addresses a structural Go modules problem where v2+ major bumps change import paths and cannot take effect until a direct dependent imports the new path

**Changed:**

- Renovate dependency update rules - Added a new rule in `.github/renovate.json5` that disables major version updates for indirect Go dependencies (`matchDepTypes: indirect`, `matchUpdateTypes: major`), preventing `go mod tidy` from stripping the requirement and causing hook failures on every generated PR