### PR TITLE
chore: update go version to 1.26.5 in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cowdogmoo/warpgate/v3
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.22.0


### PR DESCRIPTION
**Key Changes:**

- Updated Go version requirement from 1.26.4 to 1.26.5 in the module definition

**Changed:**

- Go version bump - Updated minimum Go version from `1.26.4` to `1.26.5` in `go.mod`