### PR TITLE
feat: support multiple cache types and explicit cache overrides for local templates

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,10 @@
+---
+version: "2"
+
+linters:
+  exclusions:
+    rules:
+      - path: _test\.go
+        linters:
+          - staticcheck
+        text: "SA5011"

--- a/builder/buildkit/buildkit.go
+++ b/builder/buildkit/buildkit.go
@@ -289,6 +289,24 @@ func parseCacheAttrs(cacheSpec string) map[string]string {
 	return attrs
 }
 
+// parseCacheEntry builds a BuildKit cache entry from a spec like
+// "type=registry,ref=user/app:cache,mode=max". The type is taken from the spec
+// and defaults to "registry" when absent.
+func parseCacheEntry(cacheSpec string) client.CacheOptionsEntry {
+	attrs := parseCacheAttrs(cacheSpec)
+
+	cacheType := attrs["type"]
+	if cacheType == "" {
+		cacheType = "registry"
+	}
+	delete(attrs, "type")
+
+	return client.CacheOptionsEntry{
+		Type:  cacheType,
+		Attrs: attrs,
+	}
+}
+
 // detectBuildxBuilder detects the active buildx builder using Docker SDK.
 // It scans running containers for buildx builder instances (containers with
 // names prefixed "buildx_buildkit_") and returns the builder name and container name.
@@ -846,26 +864,21 @@ func (b *BuildKitBuilder) configureCacheOptions(solveOpt *client.SolveOpt, cfg b
 	// Determine if caching should be disabled
 	// For local templates, disable caching by default to ensure changes are reflected
 	// Can be overridden with explicit cache parameters (--cache-from, --cache-to)
-	noCache := cfg.NoCache || cfg.IsLocalTemplate
+	hasExplicitCache := len(b.cacheFrom) > 0 || len(b.cacheTo) > 0
+	noCache := cfg.NoCache || (cfg.IsLocalTemplate && !hasExplicitCache)
 
 	if !noCache {
 		if len(b.cacheFrom) > 0 {
 			logging.InfoContext(ctx, "Configuring cache import from %d source(s)", len(b.cacheFrom))
 			for _, cacheSource := range b.cacheFrom {
-				solveOpt.CacheImports = append(solveOpt.CacheImports, client.CacheOptionsEntry{
-					Type:  "registry",
-					Attrs: parseCacheAttrs(cacheSource),
-				})
+				solveOpt.CacheImports = append(solveOpt.CacheImports, parseCacheEntry(cacheSource))
 			}
 		}
 
 		if len(b.cacheTo) > 0 {
 			logging.InfoContext(ctx, "Configuring cache export to %d destination(s)", len(b.cacheTo))
 			for _, cacheDest := range b.cacheTo {
-				solveOpt.CacheExports = append(solveOpt.CacheExports, client.CacheOptionsEntry{
-					Type:  "registry",
-					Attrs: parseCacheAttrs(cacheDest),
-				})
+				solveOpt.CacheExports = append(solveOpt.CacheExports, parseCacheEntry(cacheDest))
 			}
 		}
 	} else {

--- a/builder/buildkit/buildkit_test.go
+++ b/builder/buildkit/buildkit_test.go
@@ -3146,6 +3146,72 @@ func TestParseCacheAttrs(t *testing.T) {
 }
 
 // ============================================================
+// parseCacheEntry
+// ============================================================
+
+func TestParseCacheEntry(t *testing.T) {
+	tests := []struct {
+		name         string
+		input        string
+		expectType   string
+		expectAttrs  map[string]string
+		expectNoAttr []string
+	}{
+		{
+			name:         "explicit registry type",
+			input:        "type=registry,ref=user/app:cache,mode=max",
+			expectType:   "registry",
+			expectAttrs:  map[string]string{"ref": "user/app:cache", "mode": "max"},
+			expectNoAttr: []string{"type"},
+		},
+		{
+			name:        "gha type is not coerced to registry",
+			input:       "type=gha,scope=build",
+			expectType:  "gha",
+			expectAttrs: map[string]string{"scope": "build"},
+		},
+		{
+			name:        "local type is not coerced to registry",
+			input:       "type=local,dest=/tmp/cache",
+			expectType:  "local",
+			expectAttrs: map[string]string{"dest": "/tmp/cache"},
+		},
+		{
+			name:        "missing type defaults to registry",
+			input:       "ref=user/app:cache",
+			expectType:  "registry",
+			expectAttrs: map[string]string{"ref": "user/app:cache"},
+		},
+		{
+			name:        "ignore-error survives as an attribute",
+			input:       "type=registry,ref=user/app:cache,mode=max,ignore-error=true",
+			expectType:  "registry",
+			expectAttrs: map[string]string{"ignore-error": "true"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			entry := parseCacheEntry(tt.input)
+
+			if entry.Type != tt.expectType {
+				t.Errorf("Type: expected %q, got %q", tt.expectType, entry.Type)
+			}
+			for k, v := range tt.expectAttrs {
+				if entry.Attrs[k] != v {
+					t.Errorf("attr %q: expected %q, got %q", k, v, entry.Attrs[k])
+				}
+			}
+			for _, k := range tt.expectNoAttr {
+				if _, ok := entry.Attrs[k]; ok {
+					t.Errorf("attr %q should not be forwarded to BuildKit", k)
+				}
+			}
+		})
+	}
+}
+
+// ============================================================
 // loadTLSConfig
 // ============================================================
 
@@ -3380,10 +3446,26 @@ func TestConfigureCacheOptions(t *testing.T) {
 			expectExportCount: 0,
 		},
 		{
-			name:              "IsLocalTemplate disables caching",
+			name:              "IsLocalTemplate disables caching without explicit cache options",
+			cacheFrom:         []string{},
+			cacheTo:           []string{},
+			cfg:               builder.Config{IsLocalTemplate: true},
+			expectImportCount: 0,
+			expectExportCount: 0,
+		},
+		{
+			name:              "explicit cache options override IsLocalTemplate",
 			cacheFrom:         []string{"type=registry,ref=user/app:cache"},
 			cacheTo:           []string{"type=registry,ref=user/app:cache"},
 			cfg:               builder.Config{IsLocalTemplate: true},
+			expectImportCount: 1,
+			expectExportCount: 1,
+		},
+		{
+			name:              "NoCache beats explicit cache options on a local template",
+			cacheFrom:         []string{"type=registry,ref=user/app:cache"},
+			cacheTo:           []string{"type=registry,ref=user/app:cache"},
+			cfg:               builder.Config{NoCache: true, IsLocalTemplate: true},
 			expectImportCount: 0,
 			expectExportCount: 0,
 		},
@@ -6217,10 +6299,7 @@ func TestLoadTLSConfig_InvalidCACertContent(t *testing.T) {
 
 func TestConfigureCacheOptions_LocalTemplateCacheDisabled(t *testing.T) {
 	t.Parallel()
-	b := &BuildKitBuilder{
-		cacheFrom: []string{"type=registry,ref=user/app:cache"},
-		cacheTo:   []string{"type=registry,ref=user/app:cache"},
-	}
+	b := &BuildKitBuilder{}
 
 	solveOpt := &client.SolveOpt{}
 	b.configureCacheOptions(solveOpt, builder.Config{IsLocalTemplate: true})
@@ -6230,6 +6309,27 @@ func TestConfigureCacheOptions_LocalTemplateCacheDisabled(t *testing.T) {
 	}
 	if len(solveOpt.CacheExports) != 0 {
 		t.Errorf("expected 0 cache exports for local template, got %d", len(solveOpt.CacheExports))
+	}
+}
+
+func TestConfigureCacheOptions_LocalTemplateExplicitCacheOverride(t *testing.T) {
+	t.Parallel()
+	b := &BuildKitBuilder{
+		cacheFrom: []string{"type=registry,ref=user/app:cache"},
+		cacheTo:   []string{"type=registry,ref=user/app:cache,mode=max"},
+	}
+
+	solveOpt := &client.SolveOpt{}
+	b.configureCacheOptions(solveOpt, builder.Config{IsLocalTemplate: true})
+
+	if len(solveOpt.CacheImports) != 1 {
+		t.Fatalf("expected explicit --cache-from to override local template default, got %d imports", len(solveOpt.CacheImports))
+	}
+	if len(solveOpt.CacheExports) != 1 {
+		t.Fatalf("expected explicit --cache-to to override local template default, got %d exports", len(solveOpt.CacheExports))
+	}
+	if got := solveOpt.CacheExports[0].Attrs["mode"]; got != "max" {
+		t.Errorf("mode attr: expected %q, got %q", "max", got)
 	}
 }
 


### PR DESCRIPTION
**Key Changes:**

- Cache entries now honor the `type` specified in the spec (e.g. `gha`, `local`) instead of always forcing `registry`
- Explicit `--cache-from`/`--cache-to` options now override the automatic cache-disabling behavior for local templates
- Added golangci-lint configuration and expanded test coverage for cache parsing and configuration logic

**Added:**

- `parseCacheEntry` function - Builds a BuildKit cache entry from a spec string, extracting the `type` (defaulting to `registry` when absent) and forwarding remaining attributes, in `builder/buildkit/buildkit.go`
- golangci-lint configuration - Added `.golangci.yml` to exclude the `SA5011` staticcheck rule from test files
- Comprehensive cache tests - Added `TestParseCacheEntry` covering explicit types, non-coerced `gha`/`local` types, missing type defaults, and attribute preservation; added `TestConfigureCacheOptions_LocalTemplateExplicitCacheOverride` and new table cases validating override precedence, in `builder/buildkit/buildkit_test.go`

**Changed:**

- Local template caching logic - `configureCacheOptions` now only disables caching for local templates when no explicit cache options are provided, allowing users to opt back into caching via `--cache-from`/`--cache-to`, in `builder/buildkit/buildkit.go`
- Cache import/export construction - Replaced inline `client.CacheOptionsEntry` creation with calls to the new `parseCacheEntry` helper so cache type is derived from the spec rather than hardcoded to `registry`, in `builder/buildkit/buildkit.go`