### PR TITLE
test: isolate test config from developer's real warpgate config

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -32,6 +32,40 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// TestMain redirects HOME and the XDG base directories to a throwaway
+// directory so no test in this package can read or write the developer's
+// real warpgate config or cache. No config file is seeded: the baseline
+// for this package's tests is "no global config", matching CI.
+func TestMain(m *testing.M) {
+	os.Exit(runTestMain(m))
+}
+
+func runTestMain(m *testing.M) int {
+	home, err := os.MkdirTemp("", "warpgate-testhome")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to create isolated test home: %v\n", err)
+		return 1
+	}
+	defer func() {
+		if err := os.RemoveAll(home); err != nil {
+			fmt.Fprintf(os.Stderr, "failed to remove isolated test home: %v\n", err)
+		}
+	}()
+
+	for key, value := range map[string]string{
+		"HOME":            home,
+		"XDG_CONFIG_HOME": filepath.Join(home, ".config"),
+		"XDG_CACHE_HOME":  filepath.Join(home, ".cache"),
+	} {
+		if err := os.Setenv(key, value); err != nil {
+			fmt.Fprintf(os.Stderr, "failed to set %s: %v\n", key, err)
+			return 1
+		}
+	}
+
+	return m.Run()
+}
+
 // TestLoad_Defaults tests that defaults work without a config file
 func TestLoad_Defaults(t *testing.T) {
 	// Change to a temp directory where no config file exists

--- a/templates/test_helpers_test.go
+++ b/templates/test_helpers_test.go
@@ -1,11 +1,31 @@
-package main
+/*
+Copyright © 2025 Jayson Grace <jayson.e.grace@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+package templates
 
 import (
-	"bytes"
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/cowdogmoo/warpgate/v3/config"
@@ -42,7 +62,7 @@ func runTestMain(m *testing.M) int {
 	}
 
 	// Seed an empty global config so code paths that update it in place
-	// (e.g. templates.Manager.saveConfigValue) find a file to read.
+	// (e.g. Manager.saveConfigValue) find a file to read.
 	configDir := filepath.Join(home, ".config", "warpgate")
 	if err := os.MkdirAll(configDir, config.DirPermReadWriteExec); err != nil {
 		fmt.Fprintf(os.Stderr, "failed to create isolated config dir: %v\n", err)
@@ -54,66 +74,4 @@ func runTestMain(m *testing.M) int {
 	}
 
 	return m.Run()
-}
-
-func TestExecute(t *testing.T) {
-	tempDir := t.TempDir()
-	t.Setenv("XDG_CONFIG_HOME", tempDir)
-
-	originalCfgFile := cfgFile
-	cfgFile = ""
-	t.Cleanup(func() {
-		cfgFile = originalCfgFile
-	})
-
-	tests := []struct {
-		name            string
-		args            []string
-		wantErr         bool
-		wantErrContains string
-		wantContains    string
-	}{
-		{
-			name:         "help output",
-			args:         []string{"--help"},
-			wantContains: "Warpgate",
-		},
-		{
-			name:            "unknown flag",
-			args:            []string{"--unknown"},
-			wantErr:         true,
-			wantErrContains: "unknown flag",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			buf := new(bytes.Buffer)
-			rootCmd.SetOut(buf)
-			rootCmd.SetErr(buf)
-			rootCmd.SetArgs(tt.args)
-			t.Cleanup(func() {
-				rootCmd.SetOut(os.Stdout)
-				rootCmd.SetErr(os.Stderr)
-				rootCmd.SetArgs(nil)
-			})
-
-			err := Execute()
-			if tt.wantErr {
-				if err == nil {
-					t.Fatal("expected error, got nil")
-				}
-				if tt.wantErrContains != "" && !strings.Contains(err.Error(), tt.wantErrContains) {
-					t.Errorf("error %q missing %q", err.Error(), tt.wantErrContains)
-				}
-				return
-			}
-			if err != nil {
-				t.Fatalf("Execute() error = %v", err)
-			}
-			if tt.wantContains != "" && !strings.Contains(buf.String(), tt.wantContains) {
-				t.Errorf("output missing %q", tt.wantContains)
-			}
-		})
-	}
 }


### PR DESCRIPTION
**Key Changes:**

- Added `TestMain` hooks in three packages to redirect `HOME` and XDG base directories to a throwaway temp directory, preventing tests from reading or writing the developer's real warpgate config or cache
- Seeded an empty global config file in packages whose code paths update it in place (`cmd/warpgate`, `templates`) so save operations find a file to read
- Left `config` package unseeded to preserve its "no global config" baseline that matches CI behavior

**Added:**

- Test isolation in `cmd/warpgate/main_test.go` - New `TestMain`/`runTestMain` that creates an isolated temp home, sets `HOME`/`XDG_CONFIG_HOME`/`XDG_CACHE_HOME`, and seeds an empty `config.yaml`
- Test isolation in `config/config_test.go` - New `TestMain`/`runTestMain` that redirects HOME and XDG dirs without seeding a config file, matching CI's no-global-config baseline
- Test isolation in `templates/test_helpers_test.go` - New file providing `TestMain`/`runTestMain` for the templates package with seeded empty config to support `Manager.saveConfigValue` code paths