### PR TITLE
fix: honor targets[].registry when composing the image name

### DIFF
--- a/builder/buildkit/buildkit_test.go
+++ b/builder/buildkit/buildkit_test.go
@@ -8466,3 +8466,66 @@ func TestBuildDockerfile_SolveInputsError(t *testing.T) {
 		t.Errorf("unexpected error: %v", err)
 	}
 }
+
+// TestBuildDockerfile_ExportNameKeepsTargetRegistry reproduces the reported
+// misdirected push end to end: a template declaring targets[].registry used to
+// have that value dropped, so the image name fell back to the bare global
+// default and resolved one path segment short of the intended repository.
+func TestBuildDockerfile_ExportNameKeepsTargetRegistry(t *testing.T) {
+	origSolve := buildkitSolve
+	defer func() { buildkitSolve = origSolve }()
+
+	var got client.SolveOpt
+	buildkitSolve = func(_ context.Context, _ *client.Client, _ *llb.Definition, opt client.SolveOpt, ch chan *client.SolveStatus) (*client.SolveResponse, error) {
+		got = opt
+		close(ch)
+		return nil, fmt.Errorf("solve stopped by the test")
+	}
+
+	origTemp := createTempImage
+	defer func() { createTempImage = origTemp }()
+	createTempImage = func() (string, error) {
+		path := filepath.Join(t.TempDir(), "image.tar")
+		if err := os.WriteFile(path, nil, 0o644); err != nil {
+			return "", err
+		}
+		return path, nil
+	}
+
+	root := t.TempDir()
+	dockerfilePath, _ := writeDockerfileTree(t, root, filepath.Join("docker", "Dockerfile"))
+
+	cfg := builder.Config{
+		Name:    "mealie",
+		Version: "v3.24.0-woe.smoke",
+		Dockerfile: &builder.DockerfileConfig{
+			Path:    dockerfilePath,
+			Context: root,
+		},
+		Targets: []builder.Target{{
+			Type:      "container",
+			Registry:  "ghcr.io/cowdogmoo",
+			Platforms: []string{"linux/amd64"},
+			Tags:      []string{"v3.24.0-woe.smoke"},
+		}},
+	}
+
+	globalCfg := &config.Config{Registry: config.RegistryConfig{Default: "ghcr.io"}}
+	if err := builder.ApplyOverrides(context.Background(), &cfg, builder.BuildOptions{}, globalCfg); err != nil {
+		t.Fatalf("ApplyOverrides returned an error: %v", err)
+	}
+
+	b := &BuildKitBuilder{}
+	if _, err := b.BuildDockerfile(context.Background(), cfg); err == nil {
+		t.Fatal("expected the injected solve error to propagate")
+	}
+
+	if len(got.Exports) != 1 {
+		t.Fatalf("got %d exports, want exactly 1", len(got.Exports))
+	}
+
+	const want = "ghcr.io/cowdogmoo/mealie:v3.24.0-woe.smoke"
+	if name := got.Exports[0].Attrs["name"]; name != want {
+		t.Errorf("exported image name = %q, want %q", name, want)
+	}
+}

--- a/builder/options.go
+++ b/builder/options.go
@@ -153,11 +153,37 @@ func applyArchitectureOverrides(config *Config, opts BuildOptions, globalCfg *co
 	}
 }
 
-// applyRegistryOverride applies registry override to the build config
+// registryFromTargets returns the registry declared by the first container
+// target that sets one. Registry is a container-specific target field, so other
+// target types never contribute: an AMI or Proxmox build must not inherit a
+// container registry.
+func registryFromTargets(targets []Target) string {
+	for i := range targets {
+		if targets[i].Type == "container" && targets[i].Registry != "" {
+			return targets[i].Registry
+		}
+	}
+	return ""
+}
+
+// applyRegistryOverride resolves the registry the image name is composed from.
+//
+// Precedence is --registry, then the template's targets[].registry, then
+// registry.default from the global config. Config.Registry carries no yaml tag,
+// so a template can only reach it through a target; before that path existed a
+// template declaring ghcr.io/org fell through to the bare global default and
+// pushed to a repository one path segment short of the intended one.
 func applyRegistryOverride(config *Config, opts BuildOptions, globalCfg *config.Config) {
 	if opts.Registry != "" {
 		config.Registry = opts.Registry
-	} else if config.Registry == "" && globalCfg != nil {
+		return
+	}
+
+	if config.Registry == "" {
+		config.Registry = registryFromTargets(config.Targets)
+	}
+
+	if config.Registry == "" && globalCfg != nil {
 		config.Registry = globalCfg.Registry.Default
 	}
 }

--- a/builder/options_test.go
+++ b/builder/options_test.go
@@ -360,6 +360,87 @@ func TestApplyRegistryOverride(t *testing.T) {
 			},
 			wantRegistry: "docker.io",
 		},
+		{
+			name: "target registry is used when no CLI override is given",
+			config: &Config{
+				Targets: []Target{{Type: "container", Registry: "ghcr.io/cowdogmoo"}},
+			},
+			opts: BuildOptions{},
+			globalCfg: &config.Config{
+				Registry: config.RegistryConfig{Default: "ghcr.io"},
+			},
+			wantRegistry: "ghcr.io/cowdogmoo",
+		},
+		{
+			name: "CLI override beats the target registry",
+			config: &Config{
+				Targets: []Target{{Type: "container", Registry: "ghcr.io/cowdogmoo"}},
+			},
+			opts: BuildOptions{Registry: "docker.io/other"},
+			globalCfg: &config.Config{
+				Registry: config.RegistryConfig{Default: "ghcr.io"},
+			},
+			wantRegistry: "docker.io/other",
+		},
+		{
+			name: "an explicit config registry beats the target registry",
+			config: &Config{
+				Registry: "quay.io/explicit",
+				Targets:  []Target{{Type: "container", Registry: "ghcr.io/cowdogmoo"}},
+			},
+			opts: BuildOptions{},
+			globalCfg: &config.Config{
+				Registry: config.RegistryConfig{Default: "ghcr.io"},
+			},
+			wantRegistry: "quay.io/explicit",
+		},
+		{
+			name: "a non-container target registry is ignored",
+			config: &Config{
+				Targets: []Target{{Type: "ami", Registry: "ghcr.io/cowdogmoo"}},
+			},
+			opts: BuildOptions{},
+			globalCfg: &config.Config{
+				Registry: config.RegistryConfig{Default: "ghcr.io"},
+			},
+			wantRegistry: "ghcr.io",
+		},
+		{
+			name: "a container target without a registry falls through to the default",
+			config: &Config{
+				Targets: []Target{{Type: "container"}},
+			},
+			opts: BuildOptions{},
+			globalCfg: &config.Config{
+				Registry: config.RegistryConfig{Default: "ghcr.io"},
+			},
+			wantRegistry: "ghcr.io",
+		},
+		{
+			name: "the first container target that sets a registry wins",
+			config: &Config{
+				Targets: []Target{
+					{Type: "ami", Registry: "ami.example.com"},
+					{Type: "container"},
+					{Type: "container", Registry: "ghcr.io/first"},
+					{Type: "container", Registry: "ghcr.io/second"},
+				},
+			},
+			opts: BuildOptions{},
+			globalCfg: &config.Config{
+				Registry: config.RegistryConfig{Default: "ghcr.io"},
+			},
+			wantRegistry: "ghcr.io/first",
+		},
+		{
+			name: "a target registry is honored when no global config is present",
+			config: &Config{
+				Targets: []Target{{Type: "container", Registry: "ghcr.io/cowdogmoo"}},
+			},
+			opts:         BuildOptions{},
+			globalCfg:    nil,
+			wantRegistry: "ghcr.io/cowdogmoo",
+		},
 	}
 
 	for _, tt := range tests {
@@ -619,6 +700,63 @@ func TestApplyTagOverride(t *testing.T) {
 			applyTagOverride(ctx, tt.config, tt.opts)
 			if tt.config.Version != tt.wantVersion {
 				t.Errorf("applyTagOverride() version = %s, want %s", tt.config.Version, tt.wantVersion)
+			}
+		})
+	}
+}
+
+// TestRegistryFromTargets pins the target-selection rule on its own, so a change
+// to which target supplies the registry fails here rather than only through the
+// precedence table.
+func TestRegistryFromTargets(t *testing.T) {
+	tests := []struct {
+		name    string
+		targets []Target
+		want    string
+	}{
+		{
+			name:    "no targets",
+			targets: nil,
+			want:    "",
+		},
+		{
+			name:    "container target without a registry",
+			targets: []Target{{Type: "container"}},
+			want:    "",
+		},
+		{
+			name:    "container target with a registry",
+			targets: []Target{{Type: "container", Registry: "ghcr.io/cowdogmoo"}},
+			want:    "ghcr.io/cowdogmoo",
+		},
+		{
+			name:    "ami target registry is not container registry",
+			targets: []Target{{Type: "ami", Registry: "ghcr.io/cowdogmoo"}},
+			want:    "",
+		},
+		{
+			name: "azure and proxmox targets never contribute",
+			targets: []Target{
+				{Type: "azure", Registry: "azure.example.com"},
+				{Type: "proxmox", Registry: "proxmox.example.com"},
+			},
+			want: "",
+		},
+		{
+			name: "the first container target that sets one wins",
+			targets: []Target{
+				{Type: "container"},
+				{Type: "container", Registry: "ghcr.io/first"},
+				{Type: "container", Registry: "ghcr.io/second"},
+			},
+			want: "ghcr.io/first",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := registryFromTargets(tt.targets); got != tt.want {
+				t.Errorf("registryFromTargets() = %q, want %q", got, tt.want)
 			}
 		})
 	}

--- a/cmd/schema-gen/main.go
+++ b/cmd/schema-gen/main.go
@@ -114,7 +114,7 @@ func run() error {
 				map[string]interface{}{
 					"type":      "container",
 					"platforms": []string{"linux/amd64", "linux/arm64"},
-					"registry":  "ghcr.io/example/repo",
+					"registry":  "ghcr.io/example",
 					"tags":      []string{"latest", "v1.0.0"},
 					"push":      false,
 				},

--- a/schema/warpgate-template.json
+++ b/schema/warpgate-template.json
@@ -883,7 +883,7 @@
             "linux/arm64"
           ],
           "push": false,
-          "registry": "ghcr.io/example/repo",
+          "registry": "ghcr.io/example",
           "tags": [
             "latest",
             "v1.0.0"


### PR DESCRIPTION
**Key Changes:**

- Resolved the registry from the template's container target so a declared `ghcr.io/org` is no longer dropped in favor of the bare global default, which pushed images one path segment short of the intended repository
- Established explicit precedence for registry resolution: `--registry` flag, then an explicit config registry, then `targets[].registry`, then `registry.default`
- Scoped target-derived registries to `container` targets only, so AMI, Azure, and Proxmox builds never inherit a container registry

**Added:**

- `registryFromTargets` helper in `builder/options.go` returning the registry from the first container target that declares one
- Table-driven coverage for the new selection rule and the full precedence chain in `builder/options_test.go`, including non-container targets, first-container-wins ordering, and a nil global config
- End-to-end regression test in `builder/buildkit/buildkit_test.go` asserting the BuildKit export attribute resolves to `ghcr.io/cowdogmoo/mealie:v3.24.0-woe.smoke`

**Changed:**

- `applyRegistryOverride` restructured from a single if/else into an early-return chain that consults targets before the global default, with comments explaining why `Config.Registry` carries no yaml tag and why a template can only reach it through a target
- Schema example registry corrected to `ghcr.io/example` in both the generator (`cmd/schema-gen/main.go`) and the generated `schema/warpgate-template.json`, since the repository name is appended from the image name rather than included in the registry