### PR TITLE
feat: resolve push and registry from template container targets

### DIFF
--- a/builder/options.go
+++ b/builder/options.go
@@ -103,6 +103,7 @@ func ApplyOverrides(ctx context.Context, config *Config, opts BuildOptions, glob
 	applyAMITargetOverrides(config, opts)
 	applyLabelsAndBuildArgs(ctx, config, opts)
 	applyCacheOptions(config, opts)
+	warnUnappliedTargetTags(ctx, config)
 
 	return nil
 }
@@ -114,6 +115,24 @@ func applyTagOverride(ctx context.Context, config *Config, opts BuildOptions) {
 	}
 	config.Version = opts.Tags[0]
 	logging.DebugContext(ctx, "Overriding version with tag: %s", config.Version)
+}
+
+// warnUnappliedTargetTags warns about tags a container target declares that the
+// build cannot apply. The image carries the single tag in config.Version, set by
+// the template's version field or overridden by --tag, so any target tag naming
+// something else is dropped. Warning keeps that loss visible instead of leaving
+// the template to look like it published tags it never did.
+func warnUnappliedTargetTags(ctx context.Context, config *Config) {
+	for i := range config.Targets {
+		if config.Targets[i].Type != "container" {
+			continue
+		}
+		for _, tag := range config.Targets[i].Tags {
+			if tag != config.Version {
+				logging.WarnContext(ctx, "Target tag %q is not applied: the image is tagged %q from the version field (override with --tag)", tag, config.Version)
+			}
+		}
+	}
 }
 
 // applyTargetTypeFilter filters targets based on the target type override
@@ -164,6 +183,27 @@ func registryFromTargets(targets []Target) string {
 		}
 	}
 	return ""
+}
+
+// pushFromTargets reports whether any container target asks for its image to be
+// pushed once the build finishes. Push is a container-specific target field, so
+// other target types never contribute.
+func pushFromTargets(targets []Target) bool {
+	for i := range targets {
+		if targets[i].Type == "container" && targets[i].Push {
+			return true
+		}
+	}
+	return false
+}
+
+// TemplatePublishDefaults reports the publishing intent declared by a template's
+// container targets: the registry to publish to and whether to publish at all.
+// The CLI resolves these before it validates push options so that a template
+// declaring both registry and push is a complete push configuration on its own,
+// rather than a description of one that only takes effect with matching flags.
+func TemplatePublishDefaults(targets []Target) (registry string, push bool) {
+	return registryFromTargets(targets), pushFromTargets(targets)
 }
 
 // applyRegistryOverride resolves the registry the image name is composed from.

--- a/builder/options_test.go
+++ b/builder/options_test.go
@@ -761,3 +761,57 @@ func TestRegistryFromTargets(t *testing.T) {
 		})
 	}
 }
+
+func TestTemplatePublishDefaults(t *testing.T) {
+	tests := []struct {
+		name         string
+		targets      []Target
+		wantRegistry string
+		wantPush     bool
+	}{
+		{
+			name:    "no targets",
+			targets: nil,
+		},
+		{
+			name:    "container target declares neither",
+			targets: []Target{{Type: "container"}},
+		},
+		{
+			name:         "container target declares both",
+			targets:      []Target{{Type: "container", Registry: "ghcr.io/cowdogmoo", Push: true}},
+			wantRegistry: "ghcr.io/cowdogmoo",
+			wantPush:     true,
+		},
+		{
+			name:     "push without a registry is reported as declared",
+			targets:  []Target{{Type: "container", Push: true}},
+			wantPush: true,
+		},
+		{
+			name:    "ami target push is not a container push",
+			targets: []Target{{Type: "ami", Registry: "ghcr.io/cowdogmoo", Push: true}},
+		},
+		{
+			name: "any container target requesting a push is enough",
+			targets: []Target{
+				{Type: "container", Registry: "ghcr.io/first"},
+				{Type: "container", Push: true},
+			},
+			wantRegistry: "ghcr.io/first",
+			wantPush:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			registry, push := TemplatePublishDefaults(tt.targets)
+			if registry != tt.wantRegistry {
+				t.Errorf("TemplatePublishDefaults() registry = %q, want %q", registry, tt.wantRegistry)
+			}
+			if push != tt.wantPush {
+				t.Errorf("TemplatePublishDefaults() push = %v, want %v", push, tt.wantPush)
+			}
+		})
+	}
+}

--- a/builder/options_test.go
+++ b/builder/options_test.go
@@ -23,10 +23,14 @@ THE SOFTWARE.
 package builder
 
 import (
+	"bytes"
 	"context"
+	"log/slog"
+	"strings"
 	"testing"
 
 	"github.com/cowdogmoo/warpgate/v3/config"
+	"github.com/cowdogmoo/warpgate/v3/logging"
 )
 
 func TestApplyOverrides(t *testing.T) {
@@ -811,6 +815,70 @@ func TestTemplatePublishDefaults(t *testing.T) {
 			}
 			if push != tt.wantPush {
 				t.Errorf("TemplatePublishDefaults() push = %v, want %v", push, tt.wantPush)
+			}
+		})
+	}
+}
+
+func TestWarnUnappliedTargetTags(t *testing.T) {
+	tests := []struct {
+		name       string
+		config     *Config
+		wantWarned []string
+		wantQuiet  []string
+	}{
+		{
+			name: "target tag matching the version is applied",
+			config: &Config{
+				Version: "latest",
+				Targets: []Target{{Type: "container", Tags: []string{"latest"}}},
+			},
+			wantQuiet: []string{"latest"},
+		},
+		{
+			name: "target tag naming something else is dropped",
+			config: &Config{
+				Version: "latest",
+				Targets: []Target{{Type: "container", Tags: []string{"latest", "v1.0.0"}}},
+			},
+			wantWarned: []string{"v1.0.0"},
+		},
+		{
+			name: "every dropped tag is named",
+			config: &Config{
+				Version: "v2.0.0",
+				Targets: []Target{{Type: "container", Tags: []string{"latest", "stable"}}},
+			},
+			wantWarned: []string{"latest", "stable"},
+		},
+		{
+			name: "ami target tags are not container tags",
+			config: &Config{
+				Version: "latest",
+				Targets: []Target{{Type: "ami", Tags: []string{"v1.0.0"}}},
+			},
+			wantQuiet: []string{"v1.0.0"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			buf := &bytes.Buffer{}
+			logger := logging.NewCustomLogger(slog.LevelInfo)
+			logger.ConsoleWriter = buf
+
+			warnUnappliedTargetTags(logging.WithLogger(context.Background(), logger), tt.config)
+
+			out := buf.String()
+			for _, tag := range tt.wantWarned {
+				if !strings.Contains(out, tag) {
+					t.Errorf("expected a warning naming tag %q, got: %s", tag, out)
+				}
+			}
+			for _, tag := range tt.wantQuiet {
+				if strings.Contains(out, tag) {
+					t.Errorf("unexpected warning naming tag %q: %s", tag, out)
+				}
 			}
 		})
 	}

--- a/cli/validator.go
+++ b/cli/validator.go
@@ -87,15 +87,24 @@ func (v *Validator) validateKeyValueFormats(opts BuildCLIOptions) error {
 	return nil
 }
 
+// ValidatePushDependencies reports whether the options name a registry to push
+// to. It is separate from [Validator.ValidateBuildOptions] because a template's
+// targets[].registry can supply the registry, and the template is only loaded
+// after the flags have been validated. Callers run it once the template's
+// publishing defaults have been resolved into the options.
+func (v *Validator) ValidatePushDependencies(opts BuildCLIOptions) error {
+	if (opts.Push || opts.PushDigest) && opts.Registry == "" {
+		return fmt.Errorf("--push/--push-digest requires a registry: pass --registry or set targets[].registry in the template")
+	}
+
+	return nil
+}
+
 // validateOptionDependencies validates that dependent options are correctly specified.
 func (v *Validator) validateOptionDependencies(opts BuildCLIOptions) error {
 	// Validate that --push and --push-digest are mutually exclusive
 	if opts.Push && opts.PushDigest {
 		return fmt.Errorf("--push and --push-digest are mutually exclusive: use --push-digest for digest-only push, or --push for tagged push")
-	}
-
-	if (opts.Push || opts.PushDigest) && opts.Registry == "" {
-		return fmt.Errorf("--push/--push-digest requires --registry to be specified")
 	}
 
 	if opts.SaveDigests && !opts.Push && !opts.PushDigest {

--- a/cli/validator_test.go
+++ b/cli/validator_test.go
@@ -103,15 +103,6 @@ func TestValidateBuildOptions(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "push without registry",
-			opts: BuildCLIOptions{
-				ConfigFile: "warpgate.yaml",
-				Push:       true,
-			},
-			wantErr: true,
-			errMsg:  "--push/--push-digest requires --registry",
-		},
-		{
 			name: "push with registry - valid",
 			opts: BuildCLIOptions{
 				ConfigFile: "warpgate.yaml",
@@ -119,15 +110,6 @@ func TestValidateBuildOptions(t *testing.T) {
 				Registry:   "ghcr.io/myorg",
 			},
 			wantErr: false,
-		},
-		{
-			name: "push-digest without registry",
-			opts: BuildCLIOptions{
-				ConfigFile: "warpgate.yaml",
-				PushDigest: true,
-			},
-			wantErr: true,
-			errMsg:  "--push/--push-digest requires --registry",
 		},
 		{
 			name: "push-digest with registry - valid",
@@ -221,6 +203,60 @@ func TestValidateBuildOptions(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestValidatePushDependencies(t *testing.T) {
+	validator := NewValidator()
+
+	tests := []struct {
+		name    string
+		opts    BuildCLIOptions
+		wantErr bool
+	}{
+		{
+			name:    "push without registry",
+			opts:    BuildCLIOptions{ConfigFile: "warpgate.yaml", Push: true},
+			wantErr: true,
+		},
+		{
+			name:    "push-digest without registry",
+			opts:    BuildCLIOptions{ConfigFile: "warpgate.yaml", PushDigest: true},
+			wantErr: true,
+		},
+		{
+			name: "push with registry resolved from flag or template",
+			opts: BuildCLIOptions{ConfigFile: "warpgate.yaml", Push: true, Registry: "ghcr.io/myorg"},
+		},
+		{
+			name: "push-digest with registry resolved from flag or template",
+			opts: BuildCLIOptions{ConfigFile: "warpgate.yaml", PushDigest: true, Registry: "ghcr.io/myorg"},
+		},
+		{
+			name: "no push requested",
+			opts: BuildCLIOptions{ConfigFile: "warpgate.yaml"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validator.ValidatePushDependencies(tt.opts)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidatePushDependencies() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+// TestValidateBuildOptionsDefersPushRegistry documents that the flag-only pass
+// accepts a push without a registry: the template may still supply one through
+// targets[].registry, so the check belongs to ValidatePushDependencies.
+func TestValidateBuildOptionsDefersPushRegistry(t *testing.T) {
+	validator := NewValidator()
+
+	err := validator.ValidateBuildOptions(BuildCLIOptions{ConfigFile: "warpgate.yaml", Push: true})
+	if err != nil {
+		t.Errorf("ValidateBuildOptions() error = %v, want nil", err)
 	}
 }
 

--- a/cmd/warpgate/build.go
+++ b/cmd/warpgate/build.go
@@ -408,6 +408,14 @@ func loadAndValidateBuildConfig(ctx context.Context, args []string, opts *buildO
 	if err != nil {
 		return nil, fmt.Errorf("failed to load build configuration: %w", err)
 	}
+
+	// Push options are validated only now: the template can supply the registry
+	// through targets[].registry, and it is not loaded until this point.
+	applyTemplatePublishDefaults(ctx, buildConfig, opts)
+	if err := validator.ValidatePushDependencies(buildOptsToCliOpts(args, opts)); err != nil {
+		return nil, fmt.Errorf("invalid options: %w", err)
+	}
+
 	return buildConfig, nil
 }
 

--- a/cmd/warpgate/build_config.go
+++ b/cmd/warpgate/build_config.go
@@ -65,6 +65,28 @@ func buildOptsToCliOpts(args []string, opts *buildOptions) cli.BuildCLIOptions {
 	}
 }
 
+// applyTemplatePublishDefaults fills in publishing options that the template's
+// container targets declare and the command line left unset. Flags win: the
+// template only supplies what --registry and --push/--push-digest did not, so
+// resolution never changes the meaning of an explicit flag.
+func applyTemplatePublishDefaults(ctx context.Context, buildConfig *builder.Config, opts *buildOptions) {
+	if buildConfig == nil {
+		return
+	}
+
+	registry, push := builder.TemplatePublishDefaults(buildConfig.Targets)
+
+	if opts.registry == "" && registry != "" {
+		opts.registry = registry
+		logging.DebugContext(ctx, "Using registry declared by the template target: %s", registry)
+	}
+
+	if push && !opts.push && !opts.pushDigest {
+		opts.push = true
+		logging.InfoContext(ctx, "Push enabled by the template target (targets[].push)")
+	}
+}
+
 // loadBuildConfig loads configuration from template, git, or file
 func loadBuildConfig(ctx context.Context, args []string, opts *buildOptions) (*builder.Config, error) {
 	variables, err := templates.ParseVariables(opts.vars, opts.varFiles)

--- a/cmd/warpgate/build_test.go
+++ b/cmd/warpgate/build_test.go
@@ -1910,3 +1910,82 @@ func TestApplyProxmoxCLIOverrides_SkipsNonProxmoxTargets(t *testing.T) {
 		t.Errorf("CLI override leaked into non-proxmox target: got %q", cfg.Targets[0].Node)
 	}
 }
+
+func TestApplyTemplatePublishDefaults(t *testing.T) {
+	t.Parallel()
+
+	containerTargets := func(target builder.Target) []builder.Target {
+		return []builder.Target{target}
+	}
+
+	tests := []struct {
+		name         string
+		targets      []builder.Target
+		opts         buildOptions
+		wantRegistry string
+		wantPush     bool
+	}{
+		{
+			name:    "template declares nothing",
+			targets: containerTargets(builder.Target{Type: "container"}),
+		},
+		{
+			name:         "template registry fills an unset flag",
+			targets:      containerTargets(builder.Target{Type: "container", Registry: "ghcr.io/cowdogmoo"}),
+			wantRegistry: "ghcr.io/cowdogmoo",
+		},
+		{
+			name:         "registry flag wins over the template",
+			targets:      containerTargets(builder.Target{Type: "container", Registry: "ghcr.io/cowdogmoo"}),
+			opts:         buildOptions{registry: "ghcr.io/override"},
+			wantRegistry: "ghcr.io/override",
+		},
+		{
+			name:         "template push enables a push",
+			targets:      containerTargets(builder.Target{Type: "container", Registry: "ghcr.io/cowdogmoo", Push: true}),
+			wantRegistry: "ghcr.io/cowdogmoo",
+			wantPush:     true,
+		},
+		{
+			name:         "push-digest flag is not upgraded to push",
+			targets:      containerTargets(builder.Target{Type: "container", Registry: "ghcr.io/cowdogmoo", Push: true}),
+			opts:         buildOptions{pushDigest: true},
+			wantRegistry: "ghcr.io/cowdogmoo",
+			wantPush:     false,
+		},
+		{
+			name:    "ami target contributes neither",
+			targets: containerTargets(builder.Target{Type: "ami", Registry: "ghcr.io/cowdogmoo", Push: true}),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			opts := tt.opts
+			cfg := &builder.Config{Targets: tt.targets}
+			applyTemplatePublishDefaults(context.Background(), cfg, &opts)
+
+			if opts.registry != tt.wantRegistry {
+				t.Errorf("registry = %q, want %q", opts.registry, tt.wantRegistry)
+			}
+			if opts.push != tt.wantPush {
+				t.Errorf("push = %v, want %v", opts.push, tt.wantPush)
+			}
+		})
+	}
+}
+
+// TestApplyTemplatePublishDefaultsNilConfig covers the dry-run path where no
+// configuration was loaded.
+func TestApplyTemplatePublishDefaultsNilConfig(t *testing.T) {
+	t.Parallel()
+
+	opts := buildOptions{}
+	applyTemplatePublishDefaults(context.Background(), nil, &opts)
+
+	if opts.registry != "" || opts.push {
+		t.Errorf("nil config changed options: registry=%q push=%v", opts.registry, opts.push)
+	}
+}

--- a/cmd/warpgate/build_test.go
+++ b/cmd/warpgate/build_test.go
@@ -1989,3 +1989,69 @@ func TestApplyTemplatePublishDefaultsNilConfig(t *testing.T) {
 		t.Errorf("nil config changed options: registry=%q push=%v", opts.registry, opts.push)
 	}
 }
+
+// TestLoadAndValidateBuildConfigPushRegistry covers the push-dependency check
+// that can only run after the template is loaded, in both directions: a
+// container target supplying the registry, and no registry anywhere.
+func TestLoadAndValidateBuildConfigPushRegistry(t *testing.T) {
+	writeTemplate := func(t *testing.T, target string) string {
+		t.Helper()
+
+		configFile := filepath.Join(t.TempDir(), "warpgate.yaml")
+		contents := `name: test-image
+base:
+  image: "ubuntu:22.04"
+targets:
+  - type: container
+` + target + `provisioners:
+  - type: shell
+    inline:
+      - echo hello
+`
+		if err := os.WriteFile(configFile, []byte(contents), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		return configFile
+	}
+
+	t.Run("template registry satisfies push", func(t *testing.T) {
+		ctx := setupTestContext(t)
+		opts := &buildOptions{push: true}
+		configFile := writeTemplate(t, "    registry: ghcr.io/cowdogmoo\n")
+
+		if _, err := loadAndValidateBuildConfig(ctx, []string{configFile}, opts); err != nil {
+			t.Fatalf("loadAndValidateBuildConfig() unexpected error: %v", err)
+		}
+		if opts.registry != "ghcr.io/cowdogmoo" {
+			t.Errorf("registry = %q, want %q", opts.registry, "ghcr.io/cowdogmoo")
+		}
+	})
+
+	t.Run("target push enables a push", func(t *testing.T) {
+		ctx := setupTestContext(t)
+		opts := &buildOptions{}
+		configFile := writeTemplate(t, "    registry: ghcr.io/cowdogmoo\n    push: true\n")
+
+		if _, err := loadAndValidateBuildConfig(ctx, []string{configFile}, opts); err != nil {
+			t.Fatalf("loadAndValidateBuildConfig() unexpected error: %v", err)
+		}
+		if !opts.push {
+			t.Error("push = false, want true from the template target")
+		}
+	})
+
+	t.Run("push without a registry anywhere is rejected", func(t *testing.T) {
+		ctx := setupTestContext(t)
+		opts := &buildOptions{push: true}
+		configFile := writeTemplate(t, "")
+
+		_, err := loadAndValidateBuildConfig(ctx, []string{configFile}, opts)
+		if err == nil {
+			t.Fatal("expected an error when no registry is available for the push")
+		}
+		if !strings.Contains(err.Error(), "requires a registry") {
+			t.Errorf("error = %v, want it to mention the missing registry", err)
+		}
+	})
+}

--- a/docs/template-reference.md
+++ b/docs/template-reference.md
@@ -317,9 +317,8 @@ targets:
     platforms:
       - linux/amd64
       - linux/arm64
-    tags:
-      - latest
-      - ${VERSION}
+    registry: ghcr.io/myorg
+    push: true
 ```
 
 **Platform options:**
@@ -327,10 +326,21 @@ targets:
 - `linux/amd64` - x86_64 architecture
 - `linux/arm64` - ARM64/aarch64 architecture
 
+**Publishing:**
+
+- `registry` is the registry the image name is composed from and pushed to.
+  `--registry` overrides it; with neither set, `registry.default` from the
+  warpgate configuration applies.
+- `push: true` publishes the image after a successful build, as `--push` does.
+  It needs a registry from either `registry` here or `--registry`.
+- `--push-digest` is flag-only. A target `push` never becomes a digest push.
+
 **Tagging:**
 
-- Static tags: `latest`, `v1.0.0`
-- Variable tags: `${VERSION}`, `${BUILD_NUMBER}`
+The image tag comes from the template's top-level `version` field, or from
+`--tag` when that is passed. A `tags` list on the target is not applied to the
+built image, and warpgate warns for every entry naming something other than the
+resolved version.
 
 ### AMI Target
 
@@ -674,9 +684,6 @@ targets:
       - linux/amd64
       - linux/arm64
     registry: ghcr.io/myorg
-    tags:
-      - latest
-      - v1.0.0
     push: false
 ```
 


### PR DESCRIPTION
**Key Changes:**

- Container targets can now declare `registry` and `push: true` as a complete, self-sufficient publishing configuration, without requiring matching CLI flags
- Push registry validation moved out of the flag-only pass and into a post-template-load check, since the template may supply the registry
- Container target `tags` entries that cannot be applied to the built image now emit a warning instead of silently disappearing

**Added:**

- `TemplatePublishDefaults` in `builder/options.go` reports a template's declared registry and push intent from its container targets, backed by a new `pushFromTargets` helper that ignores non-container types
- `applyTemplatePublishDefaults` in `cmd/warpgate/build_config.go` fills unset publishing options from the template, with flags always winning and `--push-digest` never being upgraded to a tagged push
- `Validator.ValidatePushDependencies` in `cli/validator.go` checks the registry requirement once the template's defaults have been resolved into the options, with an error message pointing at both `--registry` and `targets[].registry`
- `warnUnappliedTargetTags` in `builder/options.go` warns for every container target tag that differs from the resolved `config.Version`, keeping the dropped tags visible
- Test coverage for publish-default resolution, the deferred push check in both directions, and the unapplied-tag warnings across `builder/options_test.go`, `cli/validator_test.go`, and `cmd/warpgate/build_test.go`

**Changed:**

- `loadAndValidateBuildConfig` in `cmd/warpgate/build.go` now applies the template's publishing defaults and runs the push-dependency validation after the configuration is loaded
- Container target documentation in `docs/template-reference.md` gained a Publishing section covering `registry`, `push`, and the flag-only nature of `--push-digest`, and the Tagging section now states that the image tag comes from `version` or `--tag` rather than from a target `tags` list

**Removed:**

- The `--push/--push-digest requires --registry` check from `validateOptionDependencies` in `cli/validator.go`, along with its two flag-only test cases, since the registry can no longer be resolved from flags alone
- `tags` lists from the container target examples in `docs/template-reference.md`, which advertised tagging behavior the build never applied