### PR TITLE
feat: apply and push every tag a container target declares

### DIFF
--- a/builder/buildkit/buildkit.go
+++ b/builder/buildkit/buildkit.go
@@ -1022,6 +1022,53 @@ func (b *BuildKitBuilder) applyPlatformFix(ctx context.Context, imageName string
 	return nil
 }
 
+// applyAdditionalTags tags the built image with every reference the template
+// declares beyond the version it was built as, and returns the references it
+// created. It runs after the platform fix so the extra tags point at the
+// corrected image rather than the one BuildKit exported.
+func (b *BuildKitBuilder) applyAdditionalTags(ctx context.Context, imageName string, cfg builder.Config) ([]string, error) {
+	refs := builder.AdditionalTagRefs(cfg)
+
+	for _, ref := range refs {
+		if err := b.Tag(ctx, imageName, ref); err != nil {
+			return nil, fmt.Errorf("failed to tag image as %q: %w", ref, err)
+		}
+
+		logging.InfoContext(ctx, "Tagged image as %s", ref)
+	}
+
+	return refs, nil
+}
+
+// finalizeImage turns a solved build into a result: it loads the exported image
+// into Docker, corrects its platform metadata, applies the tags the template
+// declares, and reads back the digest. The LLB and Dockerfile paths share every
+// step and differ only in the platform they built for and the notes they report.
+func (b *BuildKitBuilder) finalizeImage(ctx context.Context, imageTarPath, imageName string, cfg builder.Config, platform string, startTime time.Time, notes []string) (*builder.BuildResult, error) {
+	if err := b.loadAndTagImage(ctx, imageTarPath, imageName); err != nil {
+		return nil, err
+	}
+
+	if err := b.applyPlatformFix(ctx, imageName, cfg); err != nil {
+		return nil, fmt.Errorf("failed to fix image platform metadata: %w", err)
+	}
+
+	additionalRefs, err := b.applyAdditionalTags(ctx, imageName, cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	return &builder.BuildResult{
+		ImageRef:       imageName,
+		AdditionalRefs: additionalRefs,
+		Digest:         b.getLocalImageDigest(ctx, imageName),
+		Architecture:   extractArchFromPlatform(platform),
+		Platform:       platform,
+		Duration:       time.Since(startTime).String(),
+		Notes:          notes,
+	}, nil
+}
+
 // getPlatformString extracts platform string from config
 func getPlatformString(cfg builder.Config) string {
 	switch {
@@ -1241,10 +1288,7 @@ func (b *BuildKitBuilder) Build(ctx context.Context, cfg builder.Config) (*build
 
 	logging.DebugContext(ctx, "LLB definition: %d bytes", len(def.Def))
 
-	imageName := fmt.Sprintf("%s:%s", cfg.Name, cfg.Version)
-	if cfg.Registry != "" {
-		imageName = fmt.Sprintf("%s/%s", cfg.Registry, imageName)
-	}
+	imageName := builder.PrimaryImageRef(cfg)
 
 	imageTarPath, err := createTempImage()
 	if err != nil {
@@ -1291,27 +1335,8 @@ func (b *BuildKitBuilder) Build(ctx context.Context, cfg builder.Config) (*build
 		return nil, fmt.Errorf("build failed: %w", err)
 	}
 
-	if err := b.loadAndTagImage(ctx, imageTarPath, imageName); err != nil {
-		return nil, err
-	}
-
-	if err := b.applyPlatformFix(ctx, imageName, cfg); err != nil {
-		return nil, fmt.Errorf("failed to fix image platform metadata: %w", err)
-	}
-
-	digest := b.getLocalImageDigest(ctx, imageName)
-
-	duration := time.Since(startTime)
-	platform := getPlatformString(cfg)
-
-	return &builder.BuildResult{
-		ImageRef:     imageName,
-		Digest:       digest,
-		Architecture: extractArchFromPlatform(platform),
-		Platform:     platform,
-		Duration:     duration.String(),
-		Notes:        []string{"Built with native BuildKit LLB", "Image loaded to Docker"},
-	}, nil
+	return b.finalizeImage(ctx, imageTarPath, imageName, cfg, getPlatformString(cfg), startTime,
+		[]string{"Built with native BuildKit LLB", "Image loaded to Docker"})
 }
 
 // fixedWriteCloser returns a factory function for creating file-based WriteClosers.
@@ -1903,10 +1928,7 @@ func (b *BuildKitBuilder) BuildDockerfile(ctx context.Context, cfg builder.Confi
 	startTime := time.Now()
 	logging.InfoContext(ctx, "Building image from Dockerfile: %s (native BuildKit)", cfg.Name)
 
-	imageName := fmt.Sprintf("%s:%s", cfg.Name, cfg.Version)
-	if cfg.Registry != "" {
-		imageName = fmt.Sprintf("%s/%s", cfg.Registry, imageName)
-	}
+	imageName := builder.PrimaryImageRef(cfg)
 
 	frontendAttrs, localMounts, err := dockerfileSolveInputs(cfg)
 	if err != nil {
@@ -1956,26 +1978,8 @@ func (b *BuildKitBuilder) BuildDockerfile(ctx context.Context, cfg builder.Confi
 		return nil, fmt.Errorf("dockerfile build failed: %w", err)
 	}
 
-	if err := b.loadAndTagImage(ctx, imageTarPath, imageName); err != nil {
-		return nil, err
-	}
-
-	if err := b.applyPlatformFix(ctx, imageName, cfg); err != nil {
-		return nil, fmt.Errorf("failed to fix image platform metadata: %w", err)
-	}
-
-	digest := b.getLocalImageDigest(ctx, imageName)
-
-	duration := time.Since(startTime)
-
-	return &builder.BuildResult{
-		ImageRef:     imageName,
-		Digest:       digest,
-		Architecture: cfg.Architectures[0],
-		Platform:     fmt.Sprintf("linux/%s", cfg.Architectures[0]),
-		Duration:     duration.String(),
-		Notes:        []string{"Built from Dockerfile with native BuildKit", "Image loaded to Docker"},
-	}, nil
+	return b.finalizeImage(ctx, imageTarPath, imageName, cfg, fmt.Sprintf("linux/%s", cfg.Architectures[0]), startTime,
+		[]string{"Built from Dockerfile with native BuildKit", "Image loaded to Docker"})
 }
 
 // Close releases resources and closes connections to BuildKit and Docker daemons.

--- a/builder/buildkit/buildkit_test.go
+++ b/builder/buildkit/buildkit_test.go
@@ -37,6 +37,7 @@ import (
 	"math/big"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -8528,4 +8529,221 @@ func TestBuildDockerfile_ExportNameKeepsTargetRegistry(t *testing.T) {
 	if name := got.Exports[0].Attrs["name"]; name != want {
 		t.Errorf("exported image name = %q, want %q", name, want)
 	}
+}
+
+func TestApplyAdditionalTags(t *testing.T) {
+	type tagCall struct {
+		source string
+		target string
+	}
+
+	tests := []struct {
+		name      string
+		cfg       builder.Config
+		tagErr    error
+		wantCalls []tagCall
+		wantRefs  []string
+		wantErr   bool
+	}{
+		{
+			name: "no additional tags means no tagging",
+			cfg: builder.Config{
+				Name: "mealie", Version: "v3.24.0", Registry: "ghcr.io/cowdogmoo",
+				Targets: []builder.Target{{Type: "container", Tags: []string{"v3.24.0"}}},
+			},
+		},
+		{
+			name: "each declared tag is applied to the built image",
+			cfg: builder.Config{
+				Name: "mealie", Version: "v3.24.0", Registry: "ghcr.io/cowdogmoo",
+				Targets: []builder.Target{{Type: "container", Tags: []string{"latest", "stable"}}},
+			},
+			wantCalls: []tagCall{
+				{source: "ghcr.io/cowdogmoo/mealie:v3.24.0", target: "ghcr.io/cowdogmoo/mealie:latest"},
+				{source: "ghcr.io/cowdogmoo/mealie:v3.24.0", target: "ghcr.io/cowdogmoo/mealie:stable"},
+			},
+			wantRefs: []string{"ghcr.io/cowdogmoo/mealie:latest", "ghcr.io/cowdogmoo/mealie:stable"},
+		},
+		{
+			name: "a failed tag stops the build",
+			cfg: builder.Config{
+				Name: "mealie", Version: "v3.24.0",
+				Targets: []builder.Target{{Type: "container", Tags: []string{"latest"}}},
+			},
+			tagErr:  fmt.Errorf("no such image"),
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var calls []tagCall
+			mockClient := &MockDockerClient{
+				ImageTagFunc: func(_ context.Context, source, target string) error {
+					calls = append(calls, tagCall{source: source, target: target})
+					return tt.tagErr
+				},
+			}
+			b := &BuildKitBuilder{dockerClient: mockClient}
+
+			refs, err := b.applyAdditionalTags(context.Background(), builder.PrimaryImageRef(tt.cfg), tt.cfg)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("applyAdditionalTags() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr {
+				return
+			}
+			if !reflect.DeepEqual(refs, tt.wantRefs) {
+				t.Errorf("refs = %v, want %v", refs, tt.wantRefs)
+			}
+			if !reflect.DeepEqual(calls, tt.wantCalls) {
+				t.Errorf("tag calls = %v, want %v", calls, tt.wantCalls)
+			}
+		})
+	}
+}
+
+func TestFinalizeImage(t *testing.T) {
+	origLoad := daemonLoad
+	origWrite := daemonWrite
+	defer func() { daemonLoad = origLoad; daemonWrite = origWrite }()
+
+	daemonLoad = func(ref name.Reference, opts ...daemon.Option) (v1.Image, error) {
+		return mockImage(t, "linux", "amd64"), nil
+	}
+	daemonWrite = func(tag name.Tag, img v1.Image, opts ...daemon.Option) (string, error) {
+		return "", nil
+	}
+
+	imageTar := filepath.Join(t.TempDir(), "image.tar")
+	if err := os.WriteFile(imageTar, []byte("image"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := builder.Config{
+		Name:          "mealie",
+		Version:       "v3.24.0",
+		Registry:      "ghcr.io/cowdogmoo",
+		Architectures: []string{"amd64"},
+		Targets:       []builder.Target{{Type: "container", Tags: []string{"latest", "v3.24.0"}}},
+	}
+
+	var tagged []string
+	b := &BuildKitBuilder{dockerClient: &MockDockerClient{
+		ImageTagFunc: func(_ context.Context, _, target string) error {
+			tagged = append(tagged, target)
+			return nil
+		},
+	}}
+
+	result, err := b.finalizeImage(context.Background(), imageTar, builder.PrimaryImageRef(cfg), cfg,
+		"linux/amd64", time.Now(), []string{"a note"})
+	if err != nil {
+		t.Fatalf("finalizeImage() error = %v", err)
+	}
+
+	if result.ImageRef != "ghcr.io/cowdogmoo/mealie:v3.24.0" {
+		t.Errorf("ImageRef = %q, want %q", result.ImageRef, "ghcr.io/cowdogmoo/mealie:v3.24.0")
+	}
+	wantRefs := []string{"ghcr.io/cowdogmoo/mealie:latest"}
+	if !reflect.DeepEqual(result.AdditionalRefs, wantRefs) {
+		t.Errorf("AdditionalRefs = %v, want %v", result.AdditionalRefs, wantRefs)
+	}
+	if !reflect.DeepEqual(tagged, wantRefs) {
+		t.Errorf("tagged = %v, want %v", tagged, wantRefs)
+	}
+	if result.Architecture != "amd64" || result.Platform != "linux/amd64" {
+		t.Errorf("platform = %q/%q, want linux/amd64", result.Platform, result.Architecture)
+	}
+	if !reflect.DeepEqual(result.Notes, []string{"a note"}) {
+		t.Errorf("Notes = %v, want [a note]", result.Notes)
+	}
+}
+
+// TestFinalizeImageTagFailure checks a rejected tag fails the build instead of
+// returning a result that claims tags the image does not carry.
+func TestFinalizeImageTagFailure(t *testing.T) {
+	origLoad := daemonLoad
+	origWrite := daemonWrite
+	defer func() { daemonLoad = origLoad; daemonWrite = origWrite }()
+
+	daemonLoad = func(ref name.Reference, opts ...daemon.Option) (v1.Image, error) {
+		return mockImage(t, "linux", "amd64"), nil
+	}
+	daemonWrite = func(tag name.Tag, img v1.Image, opts ...daemon.Option) (string, error) {
+		return "", nil
+	}
+
+	imageTar := filepath.Join(t.TempDir(), "image.tar")
+	if err := os.WriteFile(imageTar, []byte("image"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := builder.Config{
+		Name: "mealie", Version: "v3.24.0", Architectures: []string{"amd64"},
+		Targets: []builder.Target{{Type: "container", Tags: []string{"latest"}}},
+	}
+
+	b := &BuildKitBuilder{dockerClient: &MockDockerClient{
+		ImageTagFunc: func(_ context.Context, _, _ string) error {
+			return fmt.Errorf("no such image")
+		},
+	}}
+
+	_, err := b.finalizeImage(context.Background(), imageTar, builder.PrimaryImageRef(cfg), cfg,
+		"linux/amd64", time.Now(), nil)
+	if err == nil {
+		t.Fatal("expected an error when tagging fails")
+	}
+	if !strings.Contains(err.Error(), "mealie:latest") {
+		t.Errorf("error = %v, want it to name the tag that failed", err)
+	}
+}
+
+// TestFinalizeImageLoadFailures checks the two failures that can happen before
+// tagging are reported rather than swallowed into a partial result.
+func TestFinalizeImageLoadFailures(t *testing.T) {
+	origLoad := daemonLoad
+	origWrite := daemonWrite
+	defer func() { daemonLoad = origLoad; daemonWrite = origWrite }()
+
+	daemonWrite = func(tag name.Tag, img v1.Image, opts ...daemon.Option) (string, error) {
+		return "", nil
+	}
+
+	cfg := builder.Config{Name: "mealie", Version: "v3.24.0", Architectures: []string{"amd64"}}
+
+	t.Run("the exported image cannot be read", func(t *testing.T) {
+		daemonLoad = func(ref name.Reference, opts ...daemon.Option) (v1.Image, error) {
+			return mockImage(t, "linux", "amd64"), nil
+		}
+
+		b := &BuildKitBuilder{dockerClient: &MockDockerClient{}}
+		_, err := b.finalizeImage(context.Background(), filepath.Join(t.TempDir(), "missing.tar"),
+			builder.PrimaryImageRef(cfg), cfg, "linux/amd64", time.Now(), nil)
+		if err == nil {
+			t.Fatal("expected an error when the image tar is missing")
+		}
+	})
+
+	t.Run("the platform metadata cannot be corrected", func(t *testing.T) {
+		daemonLoad = func(ref name.Reference, opts ...daemon.Option) (v1.Image, error) {
+			return nil, fmt.Errorf("daemon unreachable")
+		}
+
+		imageTar := filepath.Join(t.TempDir(), "image.tar")
+		if err := os.WriteFile(imageTar, []byte("image"), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		b := &BuildKitBuilder{dockerClient: &MockDockerClient{}}
+		_, err := b.finalizeImage(context.Background(), imageTar,
+			builder.PrimaryImageRef(cfg), cfg, "linux/amd64", time.Now(), nil)
+		if err == nil {
+			t.Fatal("expected an error when the platform fix fails")
+		}
+		if !strings.Contains(err.Error(), "platform metadata") {
+			t.Errorf("error = %v, want it to name the platform fix", err)
+		}
+	})
 }

--- a/builder/config.go
+++ b/builder/config.go
@@ -643,6 +643,10 @@ type BuildResult struct {
 	// ImageRef is the image reference for container builds
 	ImageRef string `json:"image_ref,omitempty"`
 
+	// AdditionalRefs are the extra references the image was tagged with, one
+	// per tag the container targets declare beyond the version in ImageRef
+	AdditionalRefs []string `json:"additional_refs,omitempty"`
+
 	// Digest is the image digest for container builds (used for multi-arch manifests)
 	Digest string `json:"digest,omitempty"`
 

--- a/builder/imageref.go
+++ b/builder/imageref.go
@@ -1,0 +1,68 @@
+/*
+Copyright © 2025 Jayson Grace <jayson.e.grace@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+package builder
+
+import "fmt"
+
+// ImageRef composes the reference for one tag of the configured image, applying
+// the resolved registry when the configuration carries one.
+func ImageRef(cfg Config, tag string) string {
+	ref := fmt.Sprintf("%s:%s", cfg.Name, tag)
+	if cfg.Registry != "" {
+		ref = fmt.Sprintf("%s/%s", cfg.Registry, ref)
+	}
+
+	return ref
+}
+
+// PrimaryImageRef composes the reference the build is named after: the image
+// tagged with the version the template resolved to.
+func PrimaryImageRef(cfg Config) string {
+	return ImageRef(cfg, cfg.Version)
+}
+
+// AdditionalTagRefs returns a reference for every tag the container targets
+// declare beyond the version the image already carries. Order follows the
+// template; the version itself and any repeat are dropped so no image is tagged
+// twice with the same reference.
+func AdditionalTagRefs(cfg Config) []string {
+	var refs []string
+	seen := map[string]bool{cfg.Version: true}
+
+	for i := range cfg.Targets {
+		if cfg.Targets[i].Type != "container" {
+			continue
+		}
+
+		for _, tag := range cfg.Targets[i].Tags {
+			if tag == "" || seen[tag] {
+				continue
+			}
+
+			seen[tag] = true
+			refs = append(refs, ImageRef(cfg, tag))
+		}
+	}
+
+	return refs
+}

--- a/builder/imageref_test.go
+++ b/builder/imageref_test.go
@@ -1,0 +1,136 @@
+/*
+Copyright © 2025 Jayson Grace <jayson.e.grace@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+package builder
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestImageRef(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  Config
+		tag  string
+		want string
+	}{
+		{
+			name: "no registry leaves the name bare",
+			cfg:  Config{Name: "mealie"},
+			tag:  "latest",
+			want: "mealie:latest",
+		},
+		{
+			name: "registry is prefixed whole",
+			cfg:  Config{Name: "mealie", Registry: "ghcr.io/cowdogmoo"},
+			tag:  "v3.24.0",
+			want: "ghcr.io/cowdogmoo/mealie:v3.24.0",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ImageRef(tt.cfg, tt.tag); got != tt.want {
+				t.Errorf("ImageRef() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPrimaryImageRef(t *testing.T) {
+	cfg := Config{Name: "mealie", Version: "v3.24.0", Registry: "ghcr.io/cowdogmoo"}
+
+	if got, want := PrimaryImageRef(cfg), "ghcr.io/cowdogmoo/mealie:v3.24.0"; got != want {
+		t.Errorf("PrimaryImageRef() = %q, want %q", got, want)
+	}
+}
+
+func TestAdditionalTagRefs(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  Config
+		want []string
+	}{
+		{
+			name: "no targets",
+			cfg:  Config{Name: "mealie", Version: "latest"},
+		},
+		{
+			name: "container target without tags",
+			cfg: Config{
+				Name: "mealie", Version: "latest",
+				Targets: []Target{{Type: "container"}},
+			},
+		},
+		{
+			name: "a tag equal to the version is already carried",
+			cfg: Config{
+				Name: "mealie", Version: "latest",
+				Targets: []Target{{Type: "container", Tags: []string{"latest"}}},
+			},
+		},
+		{
+			name: "extra tags become references in declaration order",
+			cfg: Config{
+				Name: "mealie", Version: "latest", Registry: "ghcr.io/cowdogmoo",
+				Targets: []Target{{Type: "container", Tags: []string{"latest", "v3.24.0", "stable"}}},
+			},
+			want: []string{"ghcr.io/cowdogmoo/mealie:v3.24.0", "ghcr.io/cowdogmoo/mealie:stable"},
+		},
+		{
+			name: "repeated and empty tags are dropped",
+			cfg: Config{
+				Name: "mealie", Version: "latest",
+				Targets: []Target{{Type: "container", Tags: []string{"stable", "", "stable"}}},
+			},
+			want: []string{"mealie:stable"},
+		},
+		{
+			name: "non-container target tags are not image tags",
+			cfg: Config{
+				Name: "mealie", Version: "latest",
+				Targets: []Target{{Type: "ami", Tags: []string{"v3.24.0"}}},
+			},
+		},
+		{
+			name: "tags from every container target are collected",
+			cfg: Config{
+				Name: "mealie", Version: "latest",
+				Targets: []Target{
+					{Type: "container", Tags: []string{"stable"}},
+					{Type: "ami", Tags: []string{"ignored"}},
+					{Type: "container", Tags: []string{"edge", "stable"}},
+				},
+			},
+			want: []string{"mealie:stable", "mealie:edge"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := AdditionalTagRefs(tt.cfg); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("AdditionalTagRefs() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/builder/manifest.go
+++ b/builder/manifest.go
@@ -73,6 +73,9 @@ type ManifestBuild struct {
 	// ImageRef is the full image reference for container builds
 	ImageRef string `json:"image_ref,omitempty"`
 
+	// AdditionalRefs are the extra references the image was tagged with
+	AdditionalRefs []string `json:"additional_refs,omitempty"`
+
 	// Digest is the SHA256 digest for container builds
 	Digest string `json:"digest,omitempty"`
 
@@ -111,14 +114,15 @@ func NewBuildManifest(config *Config, results []BuildResult, duration time.Durat
 
 	for _, result := range results {
 		build := ManifestBuild{
-			Platform:     result.Platform,
-			Architecture: result.Architecture,
-			ImageRef:     result.ImageRef,
-			Digest:       result.Digest,
-			AMIID:        result.AMIID,
-			Region:       result.Region,
-			Duration:     result.Duration,
-			Notes:        result.Notes,
+			Platform:       result.Platform,
+			Architecture:   result.Architecture,
+			ImageRef:       result.ImageRef,
+			AdditionalRefs: result.AdditionalRefs,
+			Digest:         result.Digest,
+			AMIID:          result.AMIID,
+			Region:         result.Region,
+			Duration:       result.Duration,
+			Notes:          result.Notes,
 		}
 
 		// Determine build type from result fields

--- a/builder/options.go
+++ b/builder/options.go
@@ -103,7 +103,6 @@ func ApplyOverrides(ctx context.Context, config *Config, opts BuildOptions, glob
 	applyAMITargetOverrides(config, opts)
 	applyLabelsAndBuildArgs(ctx, config, opts)
 	applyCacheOptions(config, opts)
-	warnUnappliedTargetTags(ctx, config)
 
 	return nil
 }
@@ -115,24 +114,6 @@ func applyTagOverride(ctx context.Context, config *Config, opts BuildOptions) {
 	}
 	config.Version = opts.Tags[0]
 	logging.DebugContext(ctx, "Overriding version with tag: %s", config.Version)
-}
-
-// warnUnappliedTargetTags warns about tags a container target declares that the
-// build cannot apply. The image carries the single tag in config.Version, set by
-// the template's version field or overridden by --tag, so any target tag naming
-// something else is dropped. Warning keeps that loss visible instead of leaving
-// the template to look like it published tags it never did.
-func warnUnappliedTargetTags(ctx context.Context, config *Config) {
-	for i := range config.Targets {
-		if config.Targets[i].Type != "container" {
-			continue
-		}
-		for _, tag := range config.Targets[i].Tags {
-			if tag != config.Version {
-				logging.WarnContext(ctx, "Target tag %q is not applied: the image is tagged %q from the version field (override with --tag)", tag, config.Version)
-			}
-		}
-	}
 }
 
 // applyTargetTypeFilter filters targets based on the target type override

--- a/builder/options_test.go
+++ b/builder/options_test.go
@@ -23,14 +23,10 @@ THE SOFTWARE.
 package builder
 
 import (
-	"bytes"
 	"context"
-	"log/slog"
-	"strings"
 	"testing"
 
 	"github.com/cowdogmoo/warpgate/v3/config"
-	"github.com/cowdogmoo/warpgate/v3/logging"
 )
 
 func TestApplyOverrides(t *testing.T) {
@@ -815,70 +811,6 @@ func TestTemplatePublishDefaults(t *testing.T) {
 			}
 			if push != tt.wantPush {
 				t.Errorf("TemplatePublishDefaults() push = %v, want %v", push, tt.wantPush)
-			}
-		})
-	}
-}
-
-func TestWarnUnappliedTargetTags(t *testing.T) {
-	tests := []struct {
-		name       string
-		config     *Config
-		wantWarned []string
-		wantQuiet  []string
-	}{
-		{
-			name: "target tag matching the version is applied",
-			config: &Config{
-				Version: "latest",
-				Targets: []Target{{Type: "container", Tags: []string{"latest"}}},
-			},
-			wantQuiet: []string{"latest"},
-		},
-		{
-			name: "target tag naming something else is dropped",
-			config: &Config{
-				Version: "latest",
-				Targets: []Target{{Type: "container", Tags: []string{"latest", "v1.0.0"}}},
-			},
-			wantWarned: []string{"v1.0.0"},
-		},
-		{
-			name: "every dropped tag is named",
-			config: &Config{
-				Version: "v2.0.0",
-				Targets: []Target{{Type: "container", Tags: []string{"latest", "stable"}}},
-			},
-			wantWarned: []string{"latest", "stable"},
-		},
-		{
-			name: "ami target tags are not container tags",
-			config: &Config{
-				Version: "latest",
-				Targets: []Target{{Type: "ami", Tags: []string{"v1.0.0"}}},
-			},
-			wantQuiet: []string{"v1.0.0"},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			buf := &bytes.Buffer{}
-			logger := logging.NewCustomLogger(slog.LevelInfo)
-			logger.ConsoleWriter = buf
-
-			warnUnappliedTargetTags(logging.WithLogger(context.Background(), logger), tt.config)
-
-			out := buf.String()
-			for _, tag := range tt.wantWarned {
-				if !strings.Contains(out, tag) {
-					t.Errorf("expected a warning naming tag %q, got: %s", tag, out)
-				}
-			}
-			for _, tag := range tt.wantQuiet {
-				if strings.Contains(out, tag) {
-					t.Errorf("unexpected warning naming tag %q: %s", tag, out)
-				}
 			}
 		})
 	}

--- a/builder/orchestrator.go
+++ b/builder/orchestrator.go
@@ -135,7 +135,7 @@ func (bo *BuildOrchestrator) PushMultiArch(ctx context.Context, results []BuildR
 				logging.InfoContext(ctx, "Successfully pushed %s", result.ImageRef)
 			}
 
-			return nil
+			return pushAdditionalTags(ctx, result.AdditionalRefs, registry, pushDigest, builder)
 		})
 	}
 

--- a/builder/service.go
+++ b/builder/service.go
@@ -330,6 +330,30 @@ func (s *BuildService) executeMultiArchBuild(ctx context.Context, config *Config
 	return results, nil
 }
 
+// pushAdditionalTags publishes the extra references the template declared for an
+// image. A digest push publishes no tag at all, so the extra references are
+// skipped there instead of being pushed as tags the caller asked not to create.
+func pushAdditionalTags(ctx context.Context, refs []string, registry string, pushDigest bool, bldr ContainerBuilder) error {
+	if len(refs) == 0 {
+		return nil
+	}
+
+	if pushDigest {
+		logging.InfoContext(ctx, "Skipping %d additional tag(s): --push-digest publishes by digest, not by tag", len(refs))
+		return nil
+	}
+
+	for _, ref := range refs {
+		logging.InfoContext(ctx, "Pushing additional tag: %s", ref)
+
+		if _, err := bldr.Push(ctx, ref, registry); err != nil {
+			return fmt.Errorf("failed to push additional tag %q: %w", ref, err)
+		}
+	}
+
+	return nil
+}
+
 // pushSingleArch pushes a single architecture image
 func (s *BuildService) pushSingleArch(ctx context.Context, config *Config, result BuildResult, bldr ContainerBuilder, opts BuildOptions) error {
 	logging.InfoContext(ctx, "Pushing to registry: %s", opts.Registry)
@@ -342,6 +366,10 @@ func (s *BuildService) pushSingleArch(ctx context.Context, config *Config, resul
 	digest, err := pushFn(ctx, result.ImageRef, opts.Registry)
 	if err != nil {
 		return fmt.Errorf("failed to push image: %w", err)
+	}
+
+	if err := pushAdditionalTags(ctx, result.AdditionalRefs, opts.Registry, opts.PushDigest, bldr); err != nil {
+		return err
 	}
 
 	// Use the digest from Push if available, otherwise fall back to result.Digest

--- a/builder/service_test.go
+++ b/builder/service_test.go
@@ -1670,3 +1670,111 @@ func TestFindProxmoxTarget(t *testing.T) {
 		t.Fatalf("expected nil when no proxmox target, got %+v", got)
 	}
 }
+
+func TestPushAdditionalTags(t *testing.T) {
+	tests := []struct {
+		name       string
+		refs       []string
+		pushDigest bool
+		wantPushed []string
+		wantErr    bool
+	}{
+		{
+			name: "nothing to push",
+		},
+		{
+			name:       "every additional reference is pushed",
+			refs:       []string{"ghcr.io/cowdogmoo/mealie:stable", "ghcr.io/cowdogmoo/mealie:edge"},
+			wantPushed: []string{"ghcr.io/cowdogmoo/mealie:stable", "ghcr.io/cowdogmoo/mealie:edge"},
+		},
+		{
+			name:       "a digest push publishes no tags",
+			refs:       []string{"ghcr.io/cowdogmoo/mealie:stable"},
+			pushDigest: true,
+		},
+		{
+			name:    "a failed tag push is reported",
+			refs:    []string{"ghcr.io/cowdogmoo/mealie:stable"},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var pushed []string
+			bldr := &mockContainerBuilder{
+				pushFunc: func(_ context.Context, imageRef, _ string) (string, error) {
+					pushed = append(pushed, imageRef)
+					if tt.wantErr {
+						return "", fmt.Errorf("registry rejected the push")
+					}
+					return "", nil
+				},
+			}
+
+			err := pushAdditionalTags(context.Background(), tt.refs, "ghcr.io/cowdogmoo", tt.pushDigest, bldr)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("pushAdditionalTags() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if !tt.wantErr && !reflect.DeepEqual(pushed, tt.wantPushed) {
+				t.Errorf("pushed = %v, want %v", pushed, tt.wantPushed)
+			}
+		})
+	}
+}
+
+// TestPushSingleArchPushesAdditionalTags checks the extra references travel with
+// the image through the push path, not just through the builder.
+func TestPushSingleArchPushesAdditionalTags(t *testing.T) {
+	var pushed []string
+	bldr := &mockContainerBuilder{
+		pushFunc: func(_ context.Context, imageRef, _ string) (string, error) {
+			pushed = append(pushed, imageRef)
+			return "sha256:abc", nil
+		},
+	}
+
+	service := NewBuildService(nil, nil)
+	result := BuildResult{
+		ImageRef:       "ghcr.io/cowdogmoo/mealie:v3.24.0",
+		AdditionalRefs: []string{"ghcr.io/cowdogmoo/mealie:latest"},
+		Architecture:   "amd64",
+	}
+
+	err := service.pushSingleArch(context.Background(), &Config{Name: "mealie"}, result, bldr, BuildOptions{Registry: "ghcr.io/cowdogmoo"})
+	if err != nil {
+		t.Fatalf("pushSingleArch() error = %v", err)
+	}
+
+	want := []string{"ghcr.io/cowdogmoo/mealie:v3.24.0", "ghcr.io/cowdogmoo/mealie:latest"}
+	if !reflect.DeepEqual(pushed, want) {
+		t.Errorf("pushed = %v, want %v", pushed, want)
+	}
+}
+
+// TestPushSingleArchAdditionalTagFailure checks a rejected extra tag fails the
+// push rather than being reported as a success on the strength of the first one.
+func TestPushSingleArchAdditionalTagFailure(t *testing.T) {
+	bldr := &mockContainerBuilder{
+		pushFunc: func(_ context.Context, imageRef, _ string) (string, error) {
+			if strings.HasSuffix(imageRef, ":latest") {
+				return "", fmt.Errorf("registry rejected the push")
+			}
+			return "sha256:abc", nil
+		},
+	}
+
+	service := NewBuildService(nil, nil)
+	result := BuildResult{
+		ImageRef:       "ghcr.io/cowdogmoo/mealie:v3.24.0",
+		AdditionalRefs: []string{"ghcr.io/cowdogmoo/mealie:latest"},
+	}
+
+	err := service.pushSingleArch(context.Background(), &Config{Name: "mealie"}, result, bldr, BuildOptions{Registry: "ghcr.io/cowdogmoo"})
+	if err == nil {
+		t.Fatal("expected an error when an additional tag fails to push")
+	}
+	if !strings.Contains(err.Error(), "ghcr.io/cowdogmoo/mealie:latest") {
+		t.Errorf("error = %v, want it to name the tag that failed", err)
+	}
+}

--- a/cli/output.go
+++ b/cli/output.go
@@ -56,6 +56,10 @@ func (f *OutputFormatter) DisplayBuildResult(ctx context.Context, result *builde
 		logging.InfoContext(ctx, "Image: %s", result.ImageRef)
 	}
 
+	for _, ref := range result.AdditionalRefs {
+		logging.InfoContext(ctx, "Also tagged: %s", ref)
+	}
+
 	if result.AMIID != "" {
 		logging.InfoContext(ctx, "AMI ID: %s", result.AMIID)
 		logging.InfoContext(ctx, "Region: %s", result.Region)

--- a/cli/output_test.go
+++ b/cli/output_test.go
@@ -27,11 +27,13 @@ import (
 	"context"
 	"encoding/json"
 	"io"
+	"log/slog"
 	"os"
 	"strings"
 	"testing"
 
 	"github.com/cowdogmoo/warpgate/v3/builder"
+	"github.com/cowdogmoo/warpgate/v3/logging"
 	"github.com/cowdogmoo/warpgate/v3/templates"
 )
 
@@ -837,5 +839,29 @@ func TestDisplayTemplateList_LongDescription(t *testing.T) {
 	// Verify description is truncated (should contain "...")
 	if !strings.Contains(output, "...") {
 		t.Errorf("DisplayTemplateList() long description not truncated")
+	}
+}
+
+func TestDisplayBuildResultAdditionalRefs(t *testing.T) {
+	t.Parallel()
+
+	buf := &bytes.Buffer{}
+	logger := logging.NewCustomLogger(slog.LevelInfo)
+	logger.ConsoleWriter = buf
+	ctx := logging.WithLogger(context.Background(), logger)
+
+	result := &builder.BuildResult{
+		ImageRef:       "ghcr.io/org/image:v1.0.0",
+		AdditionalRefs: []string{"ghcr.io/org/image:latest", "ghcr.io/org/image:stable"},
+		Duration:       "2m30s",
+	}
+
+	NewOutputFormatter("text").DisplayBuildResult(ctx, result)
+
+	out := buf.String()
+	for _, ref := range append([]string{result.ImageRef}, result.AdditionalRefs...) {
+		if !strings.Contains(out, ref) {
+			t.Errorf("expected the output to report %q, got: %s", ref, out)
+		}
 	}
 }

--- a/docs/template-reference.md
+++ b/docs/template-reference.md
@@ -318,6 +318,9 @@ targets:
       - linux/amd64
       - linux/arm64
     registry: ghcr.io/myorg
+    tags:
+      - latest
+      - v1.0.0
     push: true
 ```
 
@@ -337,10 +340,11 @@ targets:
 
 **Tagging:**
 
-The image tag comes from the template's top-level `version` field, or from
-`--tag` when that is passed. A `tags` list on the target is not applied to the
-built image, and warpgate warns for every entry naming something other than the
-resolved version.
+The image is built as the top-level `version` (or `--tag` when that is passed),
+then tagged with every entry in the target's `tags` list, so a single build can
+publish `v1.0.0` and `latest` together. Entries repeating the version are
+skipped, and a push publishes each tag in turn. `--push-digest` publishes by
+digest and applies no tags at all.
 
 ### AMI Target
 
@@ -684,6 +688,9 @@ targets:
       - linux/amd64
       - linux/arm64
     registry: ghcr.io/myorg
+    tags:
+      - latest
+      - v1.0.0
     push: false
 ```
 


### PR DESCRIPTION
**Key Changes:**

- Container targets now materialize their `tags` list: the image is built as the resolved version, then tagged with every additional reference the template declares, and each extra tag is pushed alongside the primary one
- Replaced the previous warn-and-drop behavior — where non-version target tags were logged as unapplied and silently discarded — with real tagging support
- Extracted a shared `builder/imageref.go` helper for composing image references, and consolidated the duplicated post-solve logic in the LLB and Dockerfile build paths into a single `finalizeImage` step

**Added:**

- Image reference composition helpers - New `builder/imageref.go` with `ImageRef`, `PrimaryImageRef`, and `AdditionalTagRefs`, the last of which collects tags across every container target in declaration order while dropping empty entries, repeats, and any tag equal to the version the image already carries
- Post-build tagging and result plumbing - `applyAdditionalTags` and `finalizeImage` in `builder/buildkit/buildkit.go` tag the platform-corrected image and report the references created via a new `AdditionalRefs` field on `builder.BuildResult` and `ManifestBuild`, so the manifest records every published reference
- Additional-tag push path - `pushAdditionalTags` in `builder/service.go` publishes each extra reference through both the single-arch and multi-arch push paths, and deliberately skips them under `--push-digest` since a digest push publishes no tag at all
- Test coverage for the new behavior - Table-driven tests for reference composition, tagging, finalize failure modes (unreadable tar, failed platform fix, rejected tag), push fan-out, and push failures, plus output formatter coverage

**Changed:**

- Build result reporting - `cli/output.go` prints an "Also tagged" line per additional reference so the extra tags are visible in build output
- Documentation - `docs/template-reference.md` now documents `tags` on container targets in both example blocks and rewrites the tagging section to describe build-then-tag semantics, version-tag deduplication, and the `--push-digest` exception

**Removed:**

- Unapplied-tag warning - Dropped `warnUnappliedTargetTags` and its call from `ApplyOverrides` in `builder/options.go`, along with its tests, since target tags are now applied rather than discarded