### PR TITLE
fix: publish multi-arch release tags as manifest lists

### DIFF
--- a/builder/builder.go
+++ b/builder/builder.go
@@ -97,6 +97,8 @@ package builder
 
 import (
 	"context"
+
+	"github.com/cowdogmoo/warpgate/v3/manifests"
 )
 
 // BuilderCreatorFunc creates a ContainerBuilder instance.
@@ -205,6 +207,18 @@ type ContainerBuilder interface {
 
 	// SetCacheOptions configures external cache sources and destinations.
 	SetCacheOptions(ctx context.Context, cacheFrom, cacheTo []string)
+
+	// CreateAndPushManifest publishes a manifest list uniting per-architecture
+	// images under a single name.
+	//
+	// manifestName is a fully qualified reference (e.g. "ghcr.io/org/img:v1.0.0").
+	// entries describe the architecture images the list spans.
+	//
+	// A multi-architecture build tags each architecture with its own name, so a
+	// release tag can only be published this way.
+	//
+	// Returns an error if the manifest cannot be created or pushed.
+	CreateAndPushManifest(ctx context.Context, manifestName string, entries []manifests.ManifestEntry) error
 }
 
 // AMIBuilder extends Builder with AWS AMI-specific operations.

--- a/builder/config.go
+++ b/builder/config.go
@@ -76,6 +76,7 @@ type Config struct {
 	BuildArgs       map[string]string `yaml:"-" json:"-"` // Build arguments (set by CLI --build-arg flags)
 	NoCache         bool              `yaml:"-" json:"-"` // Disable all caching (set by CLI --no-cache flag)
 	IsLocalTemplate bool              `yaml:"-" json:"-"` // Indicates if loaded from local path (disables caching by default)
+	SkipTargetTags  bool              `yaml:"-" json:"-"` // Suppresses the targets' tag list (set on per-architecture component builds)
 }
 
 // DockerfileConfig specifies Dockerfile-based build configuration

--- a/builder/imageref.go
+++ b/builder/imageref.go
@@ -45,7 +45,15 @@ func PrimaryImageRef(cfg Config) string {
 // declare beyond the version the image already carries. Order follows the
 // template; the version itself and any repeat are dropped so no image is tagged
 // twice with the same reference.
+//
+// A configuration with SkipTargetTags set declares none: the per-architecture
+// images of a multi-arch build are components tagged by architecture, and the
+// template's tags name the manifest list that unites them.
 func AdditionalTagRefs(cfg Config) []string {
+	if cfg.SkipTargetTags {
+		return nil
+	}
+
 	var refs []string
 	seen := map[string]bool{cfg.Version: true}
 

--- a/builder/orchestrator.go
+++ b/builder/orchestrator.go
@@ -82,6 +82,11 @@ func (bo *BuildOrchestrator) BuildMultiArch(ctx context.Context, requests []Buil
 			// Use architecture as tag to prevent local image overwrites
 			configCopy.Version = req.Architecture
 
+			// The template's tags name the manifest list that unites the
+			// architectures, so applying them here would have each architecture
+			// overwrite the other's tags locally and race them to the registry.
+			configCopy.SkipTargetTags = true
+
 			result, err := builder.Build(ctx, configCopy)
 			if err != nil {
 				logging.ErrorContext(ctx, "Failed to build %s for %s: %v", req.Config.Name, req.Architecture, err)

--- a/builder/orchestrator_test.go
+++ b/builder/orchestrator_test.go
@@ -28,6 +28,7 @@ import (
 	"testing"
 
 	"github.com/cowdogmoo/warpgate/v3/builder"
+	"github.com/cowdogmoo/warpgate/v3/manifests"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
@@ -68,6 +69,10 @@ func (m *MockContainerBuilder) Close() error {
 func (m *MockContainerBuilder) Remove(ctx context.Context, imageRef string) error {
 	args := m.Called(ctx, imageRef)
 	return args.Error(0)
+}
+
+func (m *MockContainerBuilder) CreateAndPushManifest(_ context.Context, _ string, _ []manifests.ManifestEntry) error {
+	return nil
 }
 
 func (m *MockContainerBuilder) SetCacheOptions(ctx context.Context, cacheFrom, cacheTo []string) {

--- a/builder/service.go
+++ b/builder/service.go
@@ -418,11 +418,55 @@ func (s *BuildService) pushMultiArch(ctx context.Context, config *Config, result
 		s.saveDigests(ctx, config.Name, results, opts.DigestDir)
 	}
 
-	// Note: Multi-arch manifest creation and push should be done in the command layer
-	// since it requires platform-specific handling for BuildKit
+	if err := s.publishManifestTags(ctx, config, results, bldr, opts); err != nil {
+		return err
+	}
 
 	logging.InfoContext(ctx, "Successfully pushed multi-arch images to %s", opts.Registry)
-	logging.InfoContext(ctx, "Note: Manifest creation must be done separately in the command layer")
+	return nil
+}
+
+// publishManifestTags publishes the template's version and additional tags as
+// manifest lists spanning the architecture images just pushed. A multi-arch
+// build produces one image per architecture, each tagged with its architecture,
+// so a release tag can only name the list that unites them; tagging one
+// architecture with it would publish a release that resolves to whichever
+// architecture happened to finish last.
+func (s *BuildService) publishManifestTags(ctx context.Context, config *Config, results []BuildResult, bldr ContainerBuilder, opts BuildOptions) error {
+	if opts.PushDigest {
+		logging.InfoContext(ctx, "Skipping manifest tags: --push-digest publishes by digest, not by tag")
+		return nil
+	}
+
+	tagged := *config
+	if tagged.Registry == "" {
+		tagged.Registry = opts.Registry
+	}
+
+	entries, err := CreateManifestEntries(ctx, results)
+	if err != nil {
+		return fmt.Errorf("failed to describe architectures for the manifest: %w", err)
+	}
+
+	// Every architecture has to be describable. A short list would publish a
+	// release tag that silently omits an architecture, and an empty one would
+	// point the tag at an index naming nothing at all: both are worse than
+	// leaving the previous tag in place. The images themselves are pushed by
+	// now, so report what is missing and name the command that finishes the job.
+	if len(entries) != len(results) {
+		return fmt.Errorf("only %d of %d architectures could be described for the manifest: publish the tags with 'warpgate manifests create'",
+			len(entries), len(results))
+	}
+
+	refs := append([]string{PrimaryImageRef(tagged)}, AdditionalTagRefs(tagged)...)
+	for _, ref := range refs {
+		logging.InfoContext(ctx, "Publishing multi-arch manifest: %s", ref)
+
+		if err := bldr.CreateAndPushManifest(ctx, ref, entries); err != nil {
+			return fmt.Errorf("failed to publish manifest %q: %w", ref, err)
+		}
+	}
+
 	return nil
 }
 

--- a/builder/service_test.go
+++ b/builder/service_test.go
@@ -27,11 +27,14 @@ import (
 	"fmt"
 	"os"
 	"reflect"
+	"sort"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 
 	"github.com/cowdogmoo/warpgate/v3/config"
+	"github.com/cowdogmoo/warpgate/v3/manifests"
 	"github.com/opencontainers/go-digest"
 )
 
@@ -44,6 +47,10 @@ type mockContainerBuilder struct {
 	removeFunc          func(ctx context.Context, imageRef string) error
 	closeFunc           func() error
 	setCacheOptionsFunc func(ctx context.Context, cacheFrom, cacheTo []string)
+	createManifestFunc  func(manifestName string, entries []manifests.ManifestEntry) error
+
+	manifestMu sync.Mutex
+	manifests  map[string][]manifests.ManifestEntry
 }
 
 func (m *mockContainerBuilder) Build(ctx context.Context, cfg Config) (*BuildResult, error) {
@@ -92,6 +99,35 @@ func (m *mockContainerBuilder) Close() error {
 		return m.closeFunc()
 	}
 	return nil
+}
+
+func (m *mockContainerBuilder) CreateAndPushManifest(_ context.Context, manifestName string, entries []manifests.ManifestEntry) error {
+	if m.createManifestFunc != nil {
+		return m.createManifestFunc(manifestName, entries)
+	}
+
+	m.manifestMu.Lock()
+	defer m.manifestMu.Unlock()
+	if m.manifests == nil {
+		m.manifests = map[string][]manifests.ManifestEntry{}
+	}
+	m.manifests[manifestName] = entries
+
+	return nil
+}
+
+// manifestNames returns the manifest list names published so far, sorted.
+func (m *mockContainerBuilder) manifestNames() []string {
+	m.manifestMu.Lock()
+	defer m.manifestMu.Unlock()
+
+	names := make([]string, 0, len(m.manifests))
+	for name := range m.manifests {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	return names
 }
 
 func (m *mockContainerBuilder) SetCacheOptions(ctx context.Context, cacheFrom, cacheTo []string) {
@@ -831,7 +867,7 @@ func TestPush_SingleResult(t *testing.T) {
 		return &mockContainerBuilder{
 			pushFunc: func(ctx context.Context, imageRef, registry string) (string, error) {
 				pushCalled = true
-				return "sha256:abcdef", nil
+				return "sha256:" + strings.Repeat("c", 64), nil
 			},
 		}, nil
 	}
@@ -862,7 +898,7 @@ func TestPush_MultipleResults(t *testing.T) {
 		return &mockContainerBuilder{
 			pushFunc: func(ctx context.Context, imageRef, registry string) (string, error) {
 				pushCount.Add(1)
-				return "sha256:abcdef", nil
+				return "sha256:" + strings.Repeat("c", 64), nil
 			},
 		}, nil
 	}
@@ -1110,7 +1146,7 @@ func TestPushSingleArch_SaveDigestDisabled(t *testing.T) {
 
 	err := service.pushSingleArch(context.Background(), buildConfig, result, &mockContainerBuilder{
 		pushFunc: func(ctx context.Context, imageRef, registry string) (string, error) {
-			return "sha256:abcdef", nil
+			return "sha256:" + strings.Repeat("c", 64), nil
 		},
 	}, buildOpts)
 
@@ -1184,7 +1220,7 @@ func TestPushMultiArch_SaveDigests(t *testing.T) {
 	buildKitCreator := func(ctx context.Context) (ContainerBuilder, error) {
 		return &mockContainerBuilder{
 			pushFunc: func(ctx context.Context, imageRef, registry string) (string, error) {
-				return "sha256:abcdef", nil
+				return "sha256:" + strings.Repeat("c", 64), nil
 			},
 		}, nil
 	}
@@ -1776,5 +1812,200 @@ func TestPushSingleArchAdditionalTagFailure(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "ghcr.io/cowdogmoo/mealie:latest") {
 		t.Errorf("error = %v, want it to name the tag that failed", err)
+	}
+}
+
+// recordingBuilder mirrors what the BuildKit builder derives from the config it
+// is handed, so the orchestration under test is exercised rather than stubbed.
+func recordingBuilder(built *[]string, pushed *[]string, mu *sync.Mutex) *mockContainerBuilder {
+	return &mockContainerBuilder{
+		buildFunc: func(_ context.Context, cfg Config) (*BuildResult, error) {
+			result := &BuildResult{
+				ImageRef:       PrimaryImageRef(cfg),
+				AdditionalRefs: AdditionalTagRefs(cfg),
+				Architecture:   cfg.Version,
+				Platform:       cfg.Base.Platform,
+				Digest:         "sha256:" + strings.Repeat("a", 64),
+			}
+
+			mu.Lock()
+			*built = append(*built, result.ImageRef)
+			*built = append(*built, result.AdditionalRefs...)
+			mu.Unlock()
+
+			return result, nil
+		},
+		pushFunc: func(_ context.Context, ref, _ string) (string, error) {
+			mu.Lock()
+			*pushed = append(*pushed, ref)
+			mu.Unlock()
+
+			return "sha256:" + strings.Repeat("b", 64), nil
+		},
+	}
+}
+
+func multiArchConfig() Config {
+	return Config{
+		Name:          "mealie",
+		Version:       "v3.24.0",
+		Registry:      "ghcr.io/cowdogmoo",
+		Architectures: []string{"amd64", "arm64"},
+		Targets:       []Target{{Type: "container", Registry: "ghcr.io/cowdogmoo", Tags: []string{"latest", "v3.24.0"}}},
+	}
+}
+
+// TestMultiArchComponentBuildsSkipTargetTags pins the rule that a per-architecture
+// image is a build component, not a release: it is tagged by architecture, and the
+// template's tags belong on the manifest list that unites the architectures. Tagging
+// them per architecture makes each architecture overwrite the other's :latest, and
+// publishes a release tag that resolves to whichever architecture finished last.
+func TestMultiArchComponentBuildsSkipTargetTags(t *testing.T) {
+	var mu sync.Mutex
+	var built, pushed []string
+
+	bldr := recordingBuilder(&built, &pushed, &mu)
+	svc := NewBuildService(nil, func(_ context.Context) (ContainerBuilder, error) { return bldr, nil })
+
+	results, err := svc.ExecuteContainerBuild(context.Background(), multiArchConfig(), BuildOptions{Registry: "ghcr.io/cowdogmoo"})
+	if err != nil {
+		t.Fatalf("ExecuteContainerBuild() error = %v", err)
+	}
+
+	for _, result := range results {
+		if len(result.AdditionalRefs) != 0 {
+			t.Errorf("architecture %q carries additional refs %v, want none", result.Architecture, result.AdditionalRefs)
+		}
+	}
+
+	sort.Strings(built)
+	want := []string{"ghcr.io/cowdogmoo/mealie:amd64", "ghcr.io/cowdogmoo/mealie:arm64"}
+	if !reflect.DeepEqual(built, want) {
+		t.Errorf("tagged %v, want only the per-architecture references %v", built, want)
+	}
+}
+
+// TestPushMultiArchPublishesManifestTags checks the release tags reach the registry
+// as manifest lists spanning every architecture built.
+func TestPushMultiArchPublishesManifestTags(t *testing.T) {
+	var mu sync.Mutex
+	var built, pushed []string
+
+	bldr := recordingBuilder(&built, &pushed, &mu)
+	svc := NewBuildService(nil, func(_ context.Context) (ContainerBuilder, error) { return bldr, nil })
+	cfg := multiArchConfig()
+	opts := BuildOptions{Registry: "ghcr.io/cowdogmoo", Push: true}
+
+	results, err := svc.ExecuteContainerBuild(context.Background(), cfg, opts)
+	if err != nil {
+		t.Fatalf("ExecuteContainerBuild() error = %v", err)
+	}
+	if err := svc.Push(context.Background(), cfg, results, opts); err != nil {
+		t.Fatalf("Push() error = %v", err)
+	}
+
+	wantManifests := []string{"ghcr.io/cowdogmoo/mealie:latest", "ghcr.io/cowdogmoo/mealie:v3.24.0"}
+	if got := bldr.manifestNames(); !reflect.DeepEqual(got, wantManifests) {
+		t.Errorf("manifest lists = %v, want %v", got, wantManifests)
+	}
+
+	for name, entries := range bldr.manifests {
+		if len(entries) != 2 {
+			t.Errorf("manifest %s has %d entries, want one per architecture", name, len(entries))
+		}
+	}
+
+	sort.Strings(pushed)
+	wantPushed := []string{"ghcr.io/cowdogmoo/mealie:amd64", "ghcr.io/cowdogmoo/mealie:arm64"}
+	if !reflect.DeepEqual(pushed, wantPushed) {
+		t.Errorf("pushed %v, want only the per-architecture images %v", pushed, wantPushed)
+	}
+}
+
+// TestPushMultiArchDigestPublishesNoTags checks --push-digest stays tagless: it
+// publishes neither an extra tag nor a manifest list naming one.
+func TestPushMultiArchDigestPublishesNoTags(t *testing.T) {
+	var mu sync.Mutex
+	var built, pushed []string
+
+	bldr := recordingBuilder(&built, &pushed, &mu)
+	svc := NewBuildService(nil, func(_ context.Context) (ContainerBuilder, error) { return bldr, nil })
+	cfg := multiArchConfig()
+	opts := BuildOptions{Registry: "ghcr.io/cowdogmoo", PushDigest: true}
+
+	results, err := svc.ExecuteContainerBuild(context.Background(), cfg, opts)
+	if err != nil {
+		t.Fatalf("ExecuteContainerBuild() error = %v", err)
+	}
+	if err := svc.Push(context.Background(), cfg, results, opts); err != nil {
+		t.Fatalf("Push() error = %v", err)
+	}
+
+	if got := bldr.manifestNames(); len(got) != 0 {
+		t.Errorf("manifest lists = %v, want none for a digest push", got)
+	}
+}
+
+// TestPushMultiArchRefusesEmptyManifest checks a tag is never published as an
+// index naming no architecture: leaving the old tag in place beats replacing it
+// with an empty one.
+func TestPushMultiArchRefusesEmptyManifest(t *testing.T) {
+	// A registry answering with something the manifest layer cannot parse leaves
+	// no architecture describable.
+	bldr := &mockContainerBuilder{
+		pushFunc: func(_ context.Context, _, _ string) (string, error) {
+			return "not-a-digest", nil
+		},
+	}
+	svc := NewBuildService(nil, func(_ context.Context) (ContainerBuilder, error) { return bldr, nil })
+
+	results := []BuildResult{
+		{ImageRef: "ghcr.io/cowdogmoo/mealie:amd64", Platform: "linux/amd64"},
+		{ImageRef: "ghcr.io/cowdogmoo/mealie:arm64", Platform: "linux/arm64"},
+	}
+
+	err := svc.Push(context.Background(), multiArchConfig(), results, BuildOptions{Registry: "ghcr.io/cowdogmoo", Push: true})
+	if err == nil {
+		t.Fatal("expected an error rather than an empty manifest list")
+	}
+	if !strings.Contains(err.Error(), "manifests create") {
+		t.Errorf("error = %v, want it to point at the recovery command", err)
+	}
+	if got := bldr.manifestNames(); len(got) != 0 {
+		t.Errorf("published %v, want no manifest at all", got)
+	}
+}
+
+// TestPushMultiArchRefusesPartialManifest checks a manifest is never published
+// while missing an architecture: a release tag that silently covers one of two
+// architectures is as wrong as one covering none.
+func TestPushMultiArchRefusesPartialManifest(t *testing.T) {
+	var describable atomic.Bool
+	bldr := &mockContainerBuilder{
+		pushFunc: func(_ context.Context, _, _ string) (string, error) {
+			// Only the first architecture pushed comes back describable.
+			if describable.CompareAndSwap(false, true) {
+				return "sha256:" + strings.Repeat("d", 64), nil
+			}
+
+			return "not-a-digest", nil
+		},
+	}
+	svc := NewBuildService(nil, func(_ context.Context) (ContainerBuilder, error) { return bldr, nil })
+
+	results := []BuildResult{
+		{ImageRef: "ghcr.io/cowdogmoo/mealie:amd64", Platform: "linux/amd64"},
+		{ImageRef: "ghcr.io/cowdogmoo/mealie:arm64", Platform: "linux/arm64"},
+	}
+
+	err := svc.Push(context.Background(), multiArchConfig(), results, BuildOptions{Registry: "ghcr.io/cowdogmoo", Push: true})
+	if err == nil {
+		t.Fatal("expected an error rather than a manifest missing an architecture")
+	}
+	if !strings.Contains(err.Error(), "1 of 2 architectures") {
+		t.Errorf("error = %v, want it to report how many architectures were describable", err)
+	}
+	if got := bldr.manifestNames(); len(got) != 0 {
+		t.Errorf("published %v, want no manifest at all", got)
 	}
 }

--- a/builder/service_test.go
+++ b/builder/service_test.go
@@ -2009,3 +2009,31 @@ func TestPushMultiArchRefusesPartialManifest(t *testing.T) {
 		t.Errorf("published %v, want no manifest at all", got)
 	}
 }
+
+// TestPushMultiArchReportsManifestFailure checks a registry rejecting the
+// manifest fails the push and names the tag that could not be published,
+// instead of reporting a successful build whose release tag does not exist.
+func TestPushMultiArchReportsManifestFailure(t *testing.T) {
+	bldr := &mockContainerBuilder{
+		pushFunc: func(_ context.Context, _, _ string) (string, error) {
+			return "sha256:" + strings.Repeat("e", 64), nil
+		},
+		createManifestFunc: func(manifestName string, _ []manifests.ManifestEntry) error {
+			return fmt.Errorf("registry rejected %s", manifestName)
+		},
+	}
+	svc := NewBuildService(nil, func(_ context.Context) (ContainerBuilder, error) { return bldr, nil })
+
+	results := []BuildResult{
+		{ImageRef: "ghcr.io/cowdogmoo/mealie:amd64", Platform: "linux/amd64"},
+		{ImageRef: "ghcr.io/cowdogmoo/mealie:arm64", Platform: "linux/arm64"},
+	}
+
+	err := svc.Push(context.Background(), multiArchConfig(), results, BuildOptions{Registry: "ghcr.io/cowdogmoo", Push: true})
+	if err == nil {
+		t.Fatal("expected an error when the manifest cannot be published")
+	}
+	if !strings.Contains(err.Error(), "ghcr.io/cowdogmoo/mealie:v3.24.0") {
+		t.Errorf("error = %v, want it to name the tag that failed", err)
+	}
+}

--- a/docs/template-reference.md
+++ b/docs/template-reference.md
@@ -343,8 +343,15 @@ targets:
 The image is built as the top-level `version` (or `--tag` when that is passed),
 then tagged with every entry in the target's `tags` list, so a single build can
 publish `v1.0.0` and `latest` together. Entries repeating the version are
-skipped, and a push publishes each tag in turn. `--push-digest` publishes by
-digest and applies no tags at all.
+skipped.
+
+A multi-architecture build tags differently, because there is no single image to
+tag. Each architecture is built and pushed under its own tag (`:amd64`,
+`:arm64`), and a push then publishes `version` and each entry in `tags` as
+manifest lists spanning those architectures. The tags therefore resolve to every
+architecture built rather than to whichever one finished last.
+
+`--push-digest` publishes by digest and applies no tags at all, in either mode.
 
 ### AMI Target
 


### PR DESCRIPTION
**Key Changes:**

- Multi-architecture pushes now publish the template's `version` and `tags` entries as manifest lists spanning every architecture built, instead of leaving manifest creation to the command layer
- Per-architecture component builds no longer apply the target's tag list, so architectures stop overwriting each other's `:latest` locally and racing it to the registry
- A manifest is refused outright when any architecture cannot be described, with the error naming `warpgate manifests create` as the recovery path

**Added:**

- `CreateAndPushManifest` on the `ContainerBuilder` interface, taking a fully qualified manifest name and the architecture entries the list spans - `builder/builder.go`
- `publishManifestTags` in the build service, which describes the pushed architectures, refuses partial or empty entry sets, and publishes each release reference as a manifest list - `builder/service.go`
- `SkipTargetTags` config field marking a build as a per-architecture component whose tags belong on the uniting manifest list - `builder/config.go`
- Test coverage for the new behavior in `builder/service_test.go`: component builds skipping target tags, release tags reaching the registry as manifest lists, `--push-digest` staying tagless, and refusal of empty, partial, and registry-rejected manifests, backed by a recording mock builder that derives refs from the config the way BuildKit does

**Changed:**

- `AdditionalTagRefs` returns no references when `SkipTargetTags` is set, since the template's tags name the manifest list rather than any single architecture - `builder/imageref.go`
- The multi-arch orchestrator sets `SkipTargetTags` on each per-architecture config copy alongside the existing architecture-as-version tagging - `builder/orchestrator.go`
- `--push-digest` short-circuits manifest tag publication, keeping digest pushes free of tags in multi-arch mode - `builder/service.go`
- Mock push digests in existing tests use full-length `sha256` values so the manifest layer can parse them - `builder/service_test.go`
- Template reference documents the multi-architecture tagging model: architectures are pushed under `:amd64`/`:arm64` and release tags resolve to manifest lists rather than whichever architecture finished last - `docs/template-reference.md`

**Removed:**

- The placeholder comment and log line stating that manifest creation must be done separately in the command layer - `builder/service.go`