### PR TITLE
fix: apply build overrides at push time so --tag names the release

### DIFF
--- a/builder/buildkit/buildkit_test.go
+++ b/builder/buildkit/buildkit_test.go
@@ -8512,9 +8512,7 @@ func TestBuildDockerfile_ExportNameKeepsTargetRegistry(t *testing.T) {
 	}
 
 	globalCfg := &config.Config{Registry: config.RegistryConfig{Default: "ghcr.io"}}
-	if err := builder.ApplyOverrides(context.Background(), &cfg, builder.BuildOptions{}, globalCfg); err != nil {
-		t.Fatalf("ApplyOverrides returned an error: %v", err)
-	}
+	builder.ApplyOverrides(context.Background(), &cfg, builder.BuildOptions{}, globalCfg)
 
 	b := &BuildKitBuilder{}
 	if _, err := b.BuildDockerfile(context.Background(), cfg); err == nil {

--- a/builder/options.go
+++ b/builder/options.go
@@ -91,7 +91,13 @@ type BuildOptions struct {
 
 // ApplyOverrides applies CLI/API overrides to a build configuration.
 // Precedence: BuildOptions > Config > Global Config Defaults
-func ApplyOverrides(ctx context.Context, config *Config, opts BuildOptions, globalCfg *config.Config) error {
+//
+// Every step is an assignment from options already parsed by the caller, so
+// resolution cannot fail and returns nothing. It is also idempotent: each step
+// either assigns the same value again or leaves a field it already resolved
+// alone, which is what lets the push path resolve the same configuration the
+// build resolved rather than trusting the caller to hand over a resolved copy.
+func ApplyOverrides(ctx context.Context, config *Config, opts BuildOptions, globalCfg *config.Config) {
 	if globalCfg == nil {
 		logging.WarnContext(ctx, "No global configuration provided, some defaults may not be applied")
 	}
@@ -103,8 +109,6 @@ func ApplyOverrides(ctx context.Context, config *Config, opts BuildOptions, glob
 	applyAMITargetOverrides(config, opts)
 	applyLabelsAndBuildArgs(ctx, config, opts)
 	applyCacheOptions(config, opts)
-
-	return nil
 }
 
 // applyTagOverride applies tag override to set the image version from CLI --tag flag

--- a/builder/options_test.go
+++ b/builder/options_test.go
@@ -37,7 +37,6 @@ func TestApplyOverrides(t *testing.T) {
 		config    *Config
 		opts      BuildOptions
 		globalCfg *config.Config
-		wantErr   bool
 		checkFunc func(*testing.T, *Config)
 	}{
 		{
@@ -52,7 +51,6 @@ func TestApplyOverrides(t *testing.T) {
 				TargetType: "container",
 			},
 			globalCfg: &config.Config{},
-			wantErr:   false,
 			checkFunc: func(t *testing.T, cfg *Config) {
 				if len(cfg.Targets) != 1 {
 					t.Errorf("Expected 1 target after filter, got %d", len(cfg.Targets))
@@ -71,7 +69,6 @@ func TestApplyOverrides(t *testing.T) {
 				Architectures: []string{"amd64", "arm64"},
 			},
 			globalCfg: &config.Config{},
-			wantErr:   false,
 			checkFunc: func(t *testing.T, cfg *Config) {
 				if len(cfg.Architectures) != 2 {
 					t.Errorf("Expected 2 architectures, got %d", len(cfg.Architectures))
@@ -87,7 +84,6 @@ func TestApplyOverrides(t *testing.T) {
 				Registry: "ghcr.io/myorg",
 			},
 			globalCfg: &config.Config{},
-			wantErr:   false,
 			checkFunc: func(t *testing.T, cfg *Config) {
 				if cfg.Registry != "ghcr.io/myorg" {
 					t.Errorf("Expected registry 'ghcr.io/myorg', got %s", cfg.Registry)
@@ -110,7 +106,6 @@ func TestApplyOverrides(t *testing.T) {
 				},
 			},
 			globalCfg: &config.Config{},
-			wantErr:   false,
 			checkFunc: func(t *testing.T, cfg *Config) {
 				if len(cfg.Labels) != 2 {
 					t.Errorf("Expected 2 labels, got %d", len(cfg.Labels))
@@ -129,7 +124,6 @@ func TestApplyOverrides(t *testing.T) {
 				NoCache: true,
 			},
 			globalCfg: &config.Config{},
-			wantErr:   false,
 			checkFunc: func(t *testing.T, cfg *Config) {
 				if !cfg.NoCache {
 					t.Error("Expected NoCache to be true")
@@ -148,7 +142,6 @@ func TestApplyOverrides(t *testing.T) {
 				InstanceType: "t3.large",
 			},
 			globalCfg: &config.Config{},
-			wantErr:   false,
 			checkFunc: func(t *testing.T, cfg *Config) {
 				if cfg.Targets[0].Region != "us-west-2" {
 					t.Errorf("Expected region 'us-west-2', got %s", cfg.Targets[0].Region)
@@ -163,7 +156,6 @@ func TestApplyOverrides(t *testing.T) {
 			config:    &Config{},
 			opts:      BuildOptions{},
 			globalCfg: nil,
-			wantErr:   false,
 			checkFunc: func(t *testing.T, cfg *Config) {
 				// Should not error with nil global config
 			},
@@ -177,7 +169,6 @@ func TestApplyOverrides(t *testing.T) {
 				Tags: []string{"v1.2.3"},
 			},
 			globalCfg: &config.Config{},
-			wantErr:   false,
 			checkFunc: func(t *testing.T, cfg *Config) {
 				if cfg.Version != "v1.2.3" {
 					t.Errorf("Expected version 'v1.2.3', got %s", cfg.Version)
@@ -188,11 +179,7 @@ func TestApplyOverrides(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := ApplyOverrides(ctx, tt.config, tt.opts, tt.globalCfg)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("ApplyOverrides() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
+			ApplyOverrides(ctx, tt.config, tt.opts, tt.globalCfg)
 			if tt.checkFunc != nil {
 				tt.checkFunc(t, tt.config)
 			}

--- a/builder/service.go
+++ b/builder/service.go
@@ -55,10 +55,7 @@ func NewBuildService(cfg *config.Config, buildKitCreator BuilderCreatorFunc) *Bu
 func (s *BuildService) ExecuteContainerBuild(ctx context.Context, config Config, opts BuildOptions) ([]BuildResult, error) {
 	logging.InfoContext(ctx, "Executing container build")
 
-	// Apply configuration overrides
-	if err := ApplyOverrides(ctx, &config, opts, s.globalConfig); err != nil {
-		return nil, fmt.Errorf("failed to apply overrides: %w", err)
-	}
+	ApplyOverrides(ctx, &config, opts, s.globalConfig)
 
 	bldr, err := s.buildKitCreator(ctx)
 	if err != nil {
@@ -259,6 +256,13 @@ func (s *BuildService) Push(ctx context.Context, config Config, results []BuildR
 		return fmt.Errorf("registry must be specified for push")
 	}
 
+	// Resolve the same overrides the build resolved. ExecuteContainerBuild takes
+	// its Config by value, so --tag, --registry and the resolved architectures
+	// never reach the caller's copy, and the caller passes that unresolved copy
+	// here. Composing manifest names from it published a release under the
+	// template's own version instead of the tag the operator asked for.
+	ApplyOverrides(ctx, &config, opts, s.globalConfig)
+
 	bldr, err := s.buildKitCreator(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to create builder for push: %w", err)
@@ -438,11 +442,6 @@ func (s *BuildService) publishManifestTags(ctx context.Context, config *Config, 
 		return nil
 	}
 
-	tagged := *config
-	if tagged.Registry == "" {
-		tagged.Registry = opts.Registry
-	}
-
 	entries, err := CreateManifestEntries(ctx, results)
 	if err != nil {
 		return fmt.Errorf("failed to describe architectures for the manifest: %w", err)
@@ -458,7 +457,7 @@ func (s *BuildService) publishManifestTags(ctx context.Context, config *Config, 
 			len(entries), len(results))
 	}
 
-	refs := append([]string{PrimaryImageRef(tagged)}, AdditionalTagRefs(tagged)...)
+	refs := append([]string{PrimaryImageRef(*config)}, AdditionalTagRefs(*config)...)
 	for _, ref := range refs {
 		logging.InfoContext(ctx, "Publishing multi-arch manifest: %s", ref)
 

--- a/builder/tagoverride_test.go
+++ b/builder/tagoverride_test.go
@@ -1,0 +1,212 @@
+/*
+Copyright © 2025 Jayson Grace <jayson.e.grace@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+package builder
+
+import (
+	"context"
+	"reflect"
+	"sort"
+	"sync"
+	"testing"
+
+	"github.com/cowdogmoo/warpgate/v3/config"
+)
+
+// overrideConfig is the configuration a template supplies, before any CLI
+// override reaches it: the version is the template's own, and the container
+// target declares one floating tag.
+func overrideConfig(architectures ...string) Config {
+	return Config{
+		Name:          "mealie",
+		Version:       "latest",
+		Registry:      "ghcr.io/cowdogmoo",
+		Architectures: architectures,
+		Targets:       []Target{{Type: "container", Registry: "ghcr.io/cowdogmoo", Tags: []string{"stable"}}},
+	}
+}
+
+// TestPushMultiArchAppliesTagOverride pins what --tag means for a multi-arch
+// release: it replaces the version the release is named after, and the tags the
+// target declares still publish alongside it.
+//
+// The configuration handed to Push is deliberately the unresolved one, because
+// that is what cmd/warpgate passes: ExecuteContainerBuild takes its Config by
+// value and resolves its own copy, so a test that pushes a resolved config
+// passes while the release still goes out under the template's version.
+func TestPushMultiArchAppliesTagOverride(t *testing.T) {
+	var mu sync.Mutex
+	var built, pushed []string
+
+	bldr := recordingBuilder(&built, &pushed, &mu)
+	svc := NewBuildService(nil, func(_ context.Context) (ContainerBuilder, error) { return bldr, nil })
+
+	cfg := overrideConfig("amd64", "arm64")
+	opts := BuildOptions{Registry: "ghcr.io/cowdogmoo", Push: true, Tags: []string{"v9.9.9"}}
+
+	results, err := svc.ExecuteContainerBuild(context.Background(), cfg, opts)
+	if err != nil {
+		t.Fatalf("ExecuteContainerBuild() error = %v", err)
+	}
+
+	if err := svc.Push(context.Background(), cfg, results, opts); err != nil {
+		t.Fatalf("Push() error = %v", err)
+	}
+
+	want := []string{"ghcr.io/cowdogmoo/mealie:stable", "ghcr.io/cowdogmoo/mealie:v9.9.9"}
+	if got := bldr.manifestNames(); !reflect.DeepEqual(got, want) {
+		t.Errorf("manifest lists = %v, want %v", got, want)
+	}
+}
+
+// TestPushMultiArchAppliesRegistryOverride checks --registry reaches the
+// manifest names by the same route, from a configuration that names no registry
+// at all. This used to be covered by a fallback inside publishManifestTags;
+// resolving the overrides at push time is what replaced it.
+func TestPushMultiArchAppliesRegistryOverride(t *testing.T) {
+	var mu sync.Mutex
+	var built, pushed []string
+
+	bldr := recordingBuilder(&built, &pushed, &mu)
+	svc := NewBuildService(nil, func(_ context.Context) (ContainerBuilder, error) { return bldr, nil })
+
+	cfg := Config{
+		Name:          "mealie",
+		Version:       "v3.24.0",
+		Architectures: []string{"amd64", "arm64"},
+		Targets:       []Target{{Type: "container", Tags: []string{"stable"}}},
+	}
+	opts := BuildOptions{Registry: "ghcr.io/cowdogmoo", Push: true}
+
+	results, err := svc.ExecuteContainerBuild(context.Background(), cfg, opts)
+	if err != nil {
+		t.Fatalf("ExecuteContainerBuild() error = %v", err)
+	}
+
+	if err := svc.Push(context.Background(), cfg, results, opts); err != nil {
+		t.Fatalf("Push() error = %v", err)
+	}
+
+	want := []string{"ghcr.io/cowdogmoo/mealie:stable", "ghcr.io/cowdogmoo/mealie:v3.24.0"}
+	if got := bldr.manifestNames(); !reflect.DeepEqual(got, want) {
+		t.Errorf("manifest lists = %v, want %v", got, want)
+	}
+}
+
+// TestPushSingleArchUsesOverriddenTag confirms the single-architecture path was
+// never affected: it pushes the reference the build already resolved, so --tag
+// reached it before this change and still does, and it publishes no manifest
+// list.
+func TestPushSingleArchUsesOverriddenTag(t *testing.T) {
+	var mu sync.Mutex
+	var built, pushed []string
+
+	bldr := recordingBuilder(&built, &pushed, &mu)
+	svc := NewBuildService(nil, func(_ context.Context) (ContainerBuilder, error) { return bldr, nil })
+
+	cfg := overrideConfig("amd64")
+	opts := BuildOptions{Registry: "ghcr.io/cowdogmoo", Push: true, Tags: []string{"v9.9.9"}}
+
+	results, err := svc.ExecuteContainerBuild(context.Background(), cfg, opts)
+	if err != nil {
+		t.Fatalf("ExecuteContainerBuild() error = %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("ExecuteContainerBuild() produced %d results, want 1", len(results))
+	}
+
+	if err := svc.Push(context.Background(), cfg, results, opts); err != nil {
+		t.Fatalf("Push() error = %v", err)
+	}
+
+	sort.Strings(pushed)
+	want := []string{"ghcr.io/cowdogmoo/mealie:stable", "ghcr.io/cowdogmoo/mealie:v9.9.9"}
+	if !reflect.DeepEqual(pushed, want) {
+		t.Errorf("pushed %v, want %v", pushed, want)
+	}
+	if got := bldr.manifestNames(); len(got) != 0 {
+		t.Errorf("published %v, want no manifest list for a single-architecture build", got)
+	}
+}
+
+// TestApplyOverridesIsIdempotent guards the property the push path relies on:
+// resolving a configuration that is already resolved has to leave it alone,
+// because the build and the push each resolve their own copy.
+func TestApplyOverridesIsIdempotent(t *testing.T) {
+	globalCfg := &config.Config{
+		Registry: config.RegistryConfig{Default: "ghcr.io"},
+	}
+	globalCfg.Build.DefaultArch = []string{"amd64"}
+
+	tests := []struct {
+		name string
+		cfg  func() Config
+		opts BuildOptions
+	}{
+		{
+			name: "container overrides",
+			cfg:  func() Config { return overrideConfig("amd64", "arm64") },
+			opts: BuildOptions{
+				TargetType:    "container",
+				Architectures: []string{"arm64"},
+				Registry:      "ghcr.io/cowdogmoo",
+				Tags:          []string{"v9.9.9"},
+				Labels:        map[string]string{"org.opencontainers.image.title": "mealie"},
+				BuildArgs:     map[string]string{"BASE_IMAGE": "alpine"},
+				NoCache:       true,
+			},
+		},
+		{
+			name: "ami overrides",
+			cfg: func() Config {
+				return Config{
+					Name:    "attack-box",
+					Version: "v1.0.0",
+					Targets: []Target{{Type: "ami", Region: "us-east-1"}},
+				}
+			},
+			opts: BuildOptions{Region: "us-west-2", InstanceType: "t3.large"},
+		},
+		{
+			name: "defaults from the global config only",
+			cfg:  func() Config { return Config{Name: "mealie", Version: "v1.0.0"} },
+			opts: BuildOptions{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+
+			once := tt.cfg()
+			ApplyOverrides(ctx, &once, tt.opts, globalCfg)
+
+			twice := tt.cfg()
+			ApplyOverrides(ctx, &twice, tt.opts, globalCfg)
+			ApplyOverrides(ctx, &twice, tt.opts, globalCfg)
+
+			if !reflect.DeepEqual(once, twice) {
+				t.Errorf("resolving twice produced %+v, want the same configuration as resolving once, %+v", twice, once)
+			}
+		})
+	}
+}

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -162,7 +162,7 @@ warpgate build myimage --save-digests --digest-dir ./digests
 | `--var-file`               | string   | Load variables from YAML file     |
 | `--push`                   | bool     | Push image to registry            |
 | `--registry`               | string   | Container registry URL            |
-| `--tag`                    | string[] | Additional tags for the image     |
+| `--tag`                    | string[] | Release tag; sets image version   |
 | `--label`                  | string[] | Set image labels (`key=value`)    |
 | `--build-arg`              | string[] | Dockerfile build args             |
 | `--save-digests`           | bool     | Save image digests to files       |

--- a/docs/template-reference.md
+++ b/docs/template-reference.md
@@ -340,16 +340,22 @@ targets:
 
 **Tagging:**
 
-The image is built as the top-level `version` (or `--tag` when that is passed),
-then tagged with every entry in the target's `tags` list, so a single build can
-publish `v1.0.0` and `latest` together. Entries repeating the version are
-skipped.
+`--tag` replaces the version the release is named after, and the tags the target
+declares still publish alongside it. Building a template whose `version` is
+`v1.0.0` and whose target declares `tags: [latest]` with `--tag v1.0.1`
+publishes `v1.0.1` and `latest`, and does not publish `v1.0.0`. The declared tags
+are floating aliases meant to point at whatever was built last, while `--tag`
+names this particular release. Repeating the flag applies only its first value.
+
+The image is built as the resolved version, then tagged with every entry in the
+target's `tags` list, so a single build can publish `v1.0.1` and `latest`
+together. Entries repeating the version are skipped.
 
 A multi-architecture build tags differently, because there is no single image to
 tag. Each architecture is built and pushed under its own tag (`:amd64`,
-`:arm64`), and a push then publishes `version` and each entry in `tags` as
-manifest lists spanning those architectures. The tags therefore resolve to every
-architecture built rather than to whichever one finished last.
+`:arm64`), and a push then publishes the resolved version and each entry in
+`tags` as manifest lists spanning those architectures. The tags therefore
+resolve to every architecture built rather than to whichever one finished last.
 
 `--push-digest` publishes by digest and applies no tags at all, in either mode.
 


### PR DESCRIPTION
**Key Changes:**

- Resolved build overrides inside `BuildService.Push`, so `--tag` and `--registry` reach multi-arch manifest names instead of publishing the release under the template's own version
- Made `ApplyOverrides` return nothing, since every step is an assignment from already-parsed options and cannot fail
- Added regression coverage for the tag/registry override paths and pinned the idempotence property the push path depends on
- Documented that `--tag` replaces the release version rather than adding a tag alongside it

**Added:**

- Override-resolution regression tests in `builder/tagoverride_test.go` covering the multi-arch tag override, the multi-arch registry override, the unaffected single-architecture path, and an idempotence check that resolving an already-resolved configuration leaves it unchanged

**Changed:**

- `BuildService.Push` now calls `ApplyOverrides` on its own copy of the configuration, because `ExecuteContainerBuild` takes its `Config` by value and callers therefore pass an unresolved copy to push - `builder/service.go`
- `ApplyOverrides` signature dropped its `error` return and the doc comment now records the idempotence guarantee the push path relies on; call sites in `builder/service.go`, `builder/options_test.go`, and `builder/buildkit/buildkit_test.go` updated, along with the now-unused `wantErr` fields in the table tests - `builder/options.go`
- `--tag` documentation reframed as the release tag that sets the image version, with the template reference spelling out that declared target tags still publish alongside it while the pre-override version does not - `docs/commands.md`, `docs/template-reference.md`

**Removed:**

- The local registry fallback copy in `publishManifestTags`, which composed manifest names from a partially-patched config; resolving overrides at push time supersedes it, and refs are now built directly from the resolved configuration - `builder/service.go`