### PR TITLE
fix: fail the manifest instead of publishing one missing an architecture

### DIFF
--- a/builder/manifestentries_test.go
+++ b/builder/manifestentries_test.go
@@ -1,0 +1,88 @@
+/*
+Copyright © 2025 Jayson Grace <jayson.e.grace@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+package builder
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// TestCreateManifestEntriesRefusesUnparseableDigest pins the failure mode the
+// function needs to have: a result it cannot describe drops an architecture out
+// of the manifest list, so it has to be reported rather than quietly skipped.
+func TestCreateManifestEntriesRefusesUnparseableDigest(t *testing.T) {
+	t.Parallel()
+
+	results := []BuildResult{
+		{
+			ImageRef:     "ghcr.io/cowdogmoo/mealie:amd64",
+			Architecture: "amd64",
+			Platform:     "linux/amd64",
+			Digest:       "sha256:" + strings.Repeat("a", 64),
+		},
+		{
+			ImageRef:     "ghcr.io/cowdogmoo/mealie:arm64",
+			Architecture: "arm64",
+			Platform:     "linux/arm64",
+			Digest:       "not-a-digest",
+		},
+	}
+
+	entries, err := CreateManifestEntries(context.Background(), results)
+	if err == nil {
+		t.Fatalf("CreateManifestEntries() returned %d entries and no error, want an error naming the architecture it could not describe", len(entries))
+	}
+	if entries != nil {
+		t.Errorf("CreateManifestEntries() returned %d entries alongside its error, want none", len(entries))
+	}
+	if !strings.Contains(err.Error(), "arm64") {
+		t.Errorf("error = %v, want it to name the architecture that could not be described", err)
+	}
+	if !strings.Contains(err.Error(), "1 of 2") {
+		t.Errorf("error = %v, want it to report how many architectures were describable", err)
+	}
+}
+
+// TestCreateManifestEntriesNamesResultWithoutArchitecture checks the report stays
+// useful when a push came back with nothing but a platform, which is the shape a
+// registry failure leaves behind.
+func TestCreateManifestEntriesNamesResultWithoutArchitecture(t *testing.T) {
+	t.Parallel()
+
+	results := []BuildResult{
+		{ImageRef: "ghcr.io/cowdogmoo/mealie:arm64", Platform: "linux/arm64", Digest: "not-a-digest"},
+		{ImageRef: "ghcr.io/cowdogmoo/mealie:amd64", Digest: "not-a-digest"},
+		{Digest: "not-a-digest"},
+	}
+
+	_, err := CreateManifestEntries(context.Background(), results)
+	if err == nil {
+		t.Fatal("CreateManifestEntries() returned no error for three undescribable results")
+	}
+	for _, want := range []string{"linux/arm64", "ghcr.io/cowdogmoo/mealie:amd64", "unknown architecture", "0 of 3"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error = %v, want it to mention %q", err, want)
+		}
+	}
+}

--- a/builder/orchestrator.go
+++ b/builder/orchestrator.go
@@ -55,7 +55,6 @@ type BuildRequest struct {
 	Config       Config
 	Architecture string // Target CPU architecture (e.g., "amd64", "arm64")
 	Platform     string // Full platform specification (e.g., "linux/amd64", "linux/arm64/v8")
-	Tag          string // Image tag for this specific build
 }
 
 // BuildMultiArch builds images for multiple architectures in parallel with controlled concurrency.

--- a/builder/orchestrator_test.go
+++ b/builder/orchestrator_test.go
@@ -132,7 +132,6 @@ func TestBuildMultiArch(t *testing.T) {
 					},
 					Architecture: "amd64",
 					Platform:     "linux/amd64",
-					Tag:          "test-image:1.0.0",
 				},
 				{
 					Config: builder.Config{
@@ -141,7 +140,6 @@ func TestBuildMultiArch(t *testing.T) {
 					},
 					Architecture: "arm64",
 					Platform:     "linux/arm64",
-					Tag:          "test-image:1.0.0",
 				},
 			},
 			mockBuildSetup: func(m *MockContainerBuilder, requests []builder.BuildRequest) {
@@ -169,7 +167,6 @@ func TestBuildMultiArch(t *testing.T) {
 					},
 					Architecture: "amd64",
 					Platform:     "linux/amd64",
-					Tag:          "test-image:1.0.0",
 				},
 				{
 					Config: builder.Config{
@@ -178,7 +175,6 @@ func TestBuildMultiArch(t *testing.T) {
 					},
 					Architecture: "arm64",
 					Platform:     "linux/arm64",
-					Tag:          "test-image:1.0.0",
 				},
 			},
 			mockBuildSetup: func(m *MockContainerBuilder, requests []builder.BuildRequest) {

--- a/builder/requests.go
+++ b/builder/requests.go
@@ -36,7 +36,6 @@ func CreateBuildRequests(ctx context.Context, buildConfig *Config) []BuildReques
 
 	for _, arch := range buildConfig.Architectures {
 		platform := fmt.Sprintf("linux/%s", arch)
-		tag := fmt.Sprintf("%s:%s", buildConfig.Name, buildConfig.Version)
 
 		archConfig := *buildConfig
 
@@ -48,7 +47,6 @@ func CreateBuildRequests(ctx context.Context, buildConfig *Config) []BuildReques
 			Config:       archConfig,
 			Architecture: arch,
 			Platform:     platform,
-			Tag:          tag,
 		})
 	}
 

--- a/builder/requests_test.go
+++ b/builder/requests_test.go
@@ -48,11 +48,9 @@ func TestCreateBuildRequests(t *testing.T) {
 		require.Len(t, requests, 2)
 		assert.Equal(t, "amd64", requests[0].Architecture)
 		assert.Equal(t, "linux/amd64", requests[0].Platform)
-		assert.Equal(t, "myimage:1.0.0", requests[0].Tag)
 
 		assert.Equal(t, "arm64", requests[1].Architecture)
 		assert.Equal(t, "linux/arm64", requests[1].Platform)
-		assert.Equal(t, "myimage:1.0.0", requests[1].Tag)
 	})
 
 	t.Run("single architecture", func(t *testing.T) {
@@ -65,7 +63,8 @@ func TestCreateBuildRequests(t *testing.T) {
 
 		requests := CreateBuildRequests(ctx, config)
 		require.Len(t, requests, 1)
-		assert.Equal(t, "single:2.0.0", requests[0].Tag)
+		assert.Equal(t, "amd64", requests[0].Architecture)
+		assert.Equal(t, "linux/amd64", requests[0].Platform)
 	})
 
 	t.Run("empty architectures returns no requests", func(t *testing.T) {

--- a/builder/service.go
+++ b/builder/service.go
@@ -25,6 +25,7 @@ package builder
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/cowdogmoo/warpgate/v3/config"
 	"github.com/cowdogmoo/warpgate/v3/logging"
@@ -442,19 +443,12 @@ func (s *BuildService) publishManifestTags(ctx context.Context, config *Config, 
 		return nil
 	}
 
+	// The architecture images are pushed by now, so a manifest that cannot be
+	// described leaves the release half-published: name the command that
+	// finishes the job rather than failing silently.
 	entries, err := CreateManifestEntries(ctx, results)
 	if err != nil {
-		return fmt.Errorf("failed to describe architectures for the manifest: %w", err)
-	}
-
-	// Every architecture has to be describable. A short list would publish a
-	// release tag that silently omits an architecture, and an empty one would
-	// point the tag at an index naming nothing at all: both are worse than
-	// leaving the previous tag in place. The images themselves are pushed by
-	// now, so report what is missing and name the command that finishes the job.
-	if len(entries) != len(results) {
-		return fmt.Errorf("only %d of %d architectures could be described for the manifest: publish the tags with 'warpgate manifests create'",
-			len(entries), len(results))
+		return fmt.Errorf("%w; publish the tags with 'warpgate manifests create'", err)
 	}
 
 	refs := append([]string{PrimaryImageRef(*config)}, AdditionalTagRefs(*config)...)
@@ -481,20 +475,29 @@ func (s *BuildService) saveDigests(ctx context.Context, imageName string, result
 	}
 }
 
-// CreateManifestEntries creates manifest entries from build results.
-// The actual manifest creation and push should be done in the command layer
-// since it requires platform-specific handling.
+// CreateManifestEntries describes every build result as a manifest entry. The
+// actual manifest creation and push should be done in the command layer since it
+// requires platform-specific handling.
+//
+// Every result has to be describable. Dropping the one whose digest will not
+// parse would publish a manifest list silently missing an architecture, which is
+// worse than leaving the previous list in place, so an undescribable result
+// fails the whole set instead of shrinking it.
 func CreateManifestEntries(ctx context.Context, results []BuildResult) ([]manifests.ManifestEntry, error) {
 	entries := make([]manifests.ManifestEntry, 0, len(results))
+	var undescribable []string
+
 	for _, result := range results {
 		var imageDigest digest.Digest
 		if result.Digest != "" {
-			var err error
-			imageDigest, err = digest.Parse(result.Digest)
+			parsed, err := digest.Parse(result.Digest)
 			if err != nil {
-				logging.WarnContext(ctx, "Failed to parse digest for %s: %v", result.Architecture, err)
+				name := describeResult(result)
+				logging.WarnContext(ctx, "Failed to parse digest for %s: %v", name, err)
+				undescribable = append(undescribable, name)
 				continue
 			}
+			imageDigest = parsed
 		}
 
 		platformInfo := manifests.ParsePlatform(result.Platform)
@@ -509,5 +512,23 @@ func CreateManifestEntries(ctx context.Context, results []BuildResult) ([]manife
 		})
 	}
 
+	if len(undescribable) > 0 {
+		return nil, fmt.Errorf("only %d of %d architectures could be described for the manifest: %s",
+			len(entries), len(results), strings.Join(undescribable, ", "))
+	}
+
 	return entries, nil
+}
+
+// describeResult names a build result for an error message, preferring the
+// architecture and falling back through the fields that are still set when a
+// push returned nothing usable.
+func describeResult(result BuildResult) string {
+	for _, name := range []string{result.Architecture, result.Platform, result.ImageRef} {
+		if name != "" {
+			return name
+		}
+	}
+
+	return "unknown architecture"
 }

--- a/builder/service_test.go
+++ b/builder/service_test.go
@@ -240,7 +240,7 @@ func TestCreateManifestEntries(t *testing.T) {
 				},
 			},
 			wantLen: 0,
-			wantErr: false, // Invalid digests are skipped, not errored
+			wantErr: true, // An architecture that cannot be described fails the set
 		},
 		{
 			name:    "empty results",

--- a/cmd/warpgate/manifests.go
+++ b/cmd/warpgate/manifests.go
@@ -211,7 +211,7 @@ Examples:
 	manifestsCreateCmd.Flags().BoolVar(&manifestsCreateOpts.healthCheck, "health-check", false, "Perform registry health check before operations")
 
 	manifestsCreateCmd.Flags().StringSliceVar(&manifestsCreateOpts.requireArch, "require-arch", nil, "Required architectures (comma-separated)")
-	manifestsCreateCmd.Flags().BoolVar(&manifestsCreateOpts.bestEffort, "best-effort", false, "Create manifest with available architectures")
+	manifestsCreateCmd.Flags().BoolVar(&manifestsCreateOpts.bestEffort, "best-effort", false, "Create manifest from the architectures available, skipping any missing or unreadable")
 
 	manifestsCreateCmd.Flags().StringSliceVar(&manifestsCreateOpts.annotations, "annotation", nil, "OCI annotations (key=value, can specify multiple)")
 	manifestsCreateCmd.Flags().StringSliceVar(&manifestsCreateOpts.labels, "label", nil, "OCI labels (key=value, can specify multiple)")

--- a/cmd/warpgate/manifests_create.go
+++ b/cmd/warpgate/manifests_create.go
@@ -79,8 +79,9 @@ func runManifestsCreate(cmd *cobra.Command, _ []string) error {
 func discoverAndValidateDigests(ctx context.Context) ([]manifests.DigestFile, error) {
 	// Discover digest files
 	digestFiles, err := manifests.DiscoverDigestFiles(ctx, manifests.DiscoveryOptions{
-		ImageName: manifestsCreateOpts.name,
-		Directory: manifestsCreateOpts.digestDir,
+		ImageName:  manifestsCreateOpts.name,
+		Directory:  manifestsCreateOpts.digestDir,
+		BestEffort: manifestsCreateOpts.bestEffort,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to discover digest files: %w", err)

--- a/manifests/completeness_test.go
+++ b/manifests/completeness_test.go
@@ -1,0 +1,65 @@
+/*
+Copyright © 2025 Jayson Grace <jayson.e.grace@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+package manifests
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestDiscoverDigestFilesRefusesUnparseableFile pins the completeness rule for
+// the standalone `warpgate manifests create` path: an architecture whose digest
+// file will not parse must stop the run, because skipping it publishes a
+// manifest list that silently covers fewer architectures than were built.
+func TestDiscoverDigestFilesRefusesUnparseableFile(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	write := func(name, content string) {
+		t.Helper()
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o644); err != nil {
+			t.Fatalf("writing %s: %v", name, err)
+		}
+	}
+	write("digest-mealie-amd64.txt", "sha256:"+strings.Repeat("a", 64))
+	write("digest-mealie-arm64.txt", "not-a-digest")
+
+	files, err := DiscoverDigestFiles(context.Background(), DiscoveryOptions{
+		ImageName: "mealie",
+		Directory: dir,
+	})
+	if err == nil {
+		t.Fatalf("DiscoverDigestFiles() returned %d file(s) and no error, want a refusal naming the file it could not read", len(files))
+	}
+	if files != nil {
+		t.Errorf("DiscoverDigestFiles() returned %d file(s) alongside its error, want none", len(files))
+	}
+	for _, want := range []string{"digest-mealie-arm64.txt", "1 of 2", "--best-effort"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error = %v, want it to mention %q", err, want)
+		}
+	}
+}

--- a/manifests/digest.go
+++ b/manifests/digest.go
@@ -48,6 +48,11 @@ type DigestFile struct {
 type DiscoveryOptions struct {
 	ImageName string
 	Directory string
+
+	// BestEffort keeps discovery going past a digest file that cannot be read.
+	// Skipping one drops that architecture from every manifest built from the
+	// result, so it happens only when the operator asked for a partial manifest.
+	BestEffort bool
 }
 
 // CreationOptions contains options for creating manifests
@@ -70,7 +75,13 @@ type ManifestEntry struct {
 	Variant      string
 }
 
-// DiscoverDigestFiles discovers and parses digest files in the specified directory
+// DiscoverDigestFiles discovers and parses digest files in the specified
+// directory.
+//
+// A digest file that will not parse is an architecture the caller has on disk
+// and cannot publish. Skipping it quietly produces a manifest list missing that
+// architecture, so discovery fails unless BestEffort says a partial manifest was
+// asked for.
 func DiscoverDigestFiles(ctx context.Context, opts DiscoveryOptions) ([]DigestFile, error) {
 	logging.InfoContext(ctx, "Discovering digest files in %s", opts.Directory)
 
@@ -86,13 +97,22 @@ func DiscoverDigestFiles(ctx context.Context, opts DiscoveryOptions) ([]DigestFi
 	}
 
 	digestFiles := make([]DigestFile, 0, len(matches))
+	var unreadable []string
 	for _, path := range matches {
 		df, err := ParseDigestFile(path)
 		if err != nil {
-			logging.WarnContext(ctx, "Skipping invalid digest file %s: %v", path, err)
+			logging.WarnContext(ctx, "Failed to parse digest file %s: %v", path, err)
+			if !opts.BestEffort {
+				unreadable = append(unreadable, filepath.Base(path))
+			}
 			continue
 		}
 		digestFiles = append(digestFiles, df)
+	}
+
+	if len(unreadable) > 0 {
+		return nil, fmt.Errorf("only %d of %d digest files for %s could be read, so a manifest built from them would omit an architecture: %s (use --best-effort to publish a partial manifest)",
+			len(digestFiles), len(matches), opts.ImageName, strings.Join(unreadable, ", "))
 	}
 
 	return digestFiles, nil

--- a/manifests/digest_test.go
+++ b/manifests/digest_test.go
@@ -269,7 +269,7 @@ func TestSaveDigestToFile_ThenParse(t *testing.T) {
 	assert.Equal(t, digestStr, df.Digest.String())
 }
 
-func TestDiscoverDigestFiles_WithInvalidFile(t *testing.T) {
+func TestDiscoverDigestFilesBestEffortSkipsUnparseableFile(t *testing.T) {
 	t.Parallel()
 
 	tmpDir := t.TempDir()
@@ -288,12 +288,14 @@ func TestDiscoverDigestFiles_WithInvalidFile(t *testing.T) {
 	))
 
 	digestFiles, err := DiscoverDigestFiles(context.Background(), DiscoveryOptions{
-		ImageName: "myimage",
-		Directory: tmpDir,
+		ImageName:  "myimage",
+		Directory:  tmpDir,
+		BestEffort: true,
 	})
 
+	// --best-effort is the operator saying a partial manifest is what they want,
+	// so the unreadable architecture is skipped instead of failing the run.
 	require.NoError(t, err)
-	// The invalid file should be skipped, only the valid one returned
 	assert.Len(t, digestFiles, 1)
 	assert.Equal(t, "amd64", digestFiles[0].Architecture)
 }


### PR DESCRIPTION
**Key Changes:**

- `CreateManifestEntries` now returns an error naming every build result it could not describe, instead of silently dropping that architecture from the manifest list
- `DiscoverDigestFiles` refuses a digest file that will not parse and points the operator at `--best-effort`, which is now the only way to publish a partial manifest
- `--best-effort` is finally wired through from `manifests create` to discovery, so the flag means what its help text claims
- Removed the unused per-request `Tag` field from `BuildRequest`, which was computed on every build and never read

**Added:**

- Completeness tests for both paths — `builder/manifestentries_test.go` pins that an unparseable digest fails the set, names the architecture, and reports how many were describable; `manifests/completeness_test.go` pins the equivalent refusal for standalone digest-file discovery
- `BestEffort` field on `DiscoveryOptions`, documented as the operator explicitly asking for a manifest that omits architectures - `manifests/digest.go`
- `describeResult` helper that names a build result for error output, falling back from architecture to platform to image ref to "unknown architecture" so a push that returned almost nothing still produces a useful report - `builder/service.go`

**Changed:**

- Failure reporting moved from the caller into `CreateManifestEntries` itself, so the function owns the completeness rule and `publishManifestTags` only appends the remediation command (`warpgate manifests create`) to the wrapped error - `builder/service.go`
- Digest parse failures in discovery are collected rather than logged-and-forgotten, and the resulting error explains that a manifest built from the readable files would omit an architecture - `manifests/digest.go`
- `--best-effort` help text now states that missing or unreadable architectures are skipped, rather than the vague "with available architectures" - `cmd/warpgate/manifests.go`
- Existing tests updated to the new contract: the invalid-digest case in `builder/service_test.go` expects an error, `TestDiscoverDigestFiles_WithInvalidFile` was renamed to `TestDiscoverDigestFilesBestEffortSkipsUnparseableFile` and opts into `BestEffort`, and the `Tag` assertions in `builder/requests_test.go` and `builder/orchestrator_test.go` were replaced with architecture/platform assertions

**Removed:**

- `Tag` field on `BuildRequest` and its construction in `CreateBuildRequests` - `builder/orchestrator.go`, `builder/requests.go`