### PR TITLE
feat: publish every requested tag beside the release

### DIFF
--- a/builder/config.go
+++ b/builder/config.go
@@ -76,7 +76,8 @@ type Config struct {
 	BuildArgs       map[string]string `yaml:"-" json:"-"` // Build arguments (set by CLI --build-arg flags)
 	NoCache         bool              `yaml:"-" json:"-"` // Disable all caching (set by CLI --no-cache flag)
 	IsLocalTemplate bool              `yaml:"-" json:"-"` // Indicates if loaded from local path (disables caching by default)
-	SkipTargetTags  bool              `yaml:"-" json:"-"` // Suppresses the targets' tag list (set on per-architecture component builds)
+	ExtraTags       []string          `yaml:"-" json:"-"` // Tags requested on the command line beyond the one that set Version
+	SkipReleaseTags bool              `yaml:"-" json:"-"` // Suppresses every release tag, requested or declared (set on per-architecture component builds)
 }
 
 // DockerfileConfig specifies Dockerfile-based build configuration

--- a/builder/extratags_test.go
+++ b/builder/extratags_test.go
@@ -1,0 +1,122 @@
+/*
+Copyright © 2025 Jayson Grace <jayson.e.grace@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+package builder
+
+import (
+	"context"
+	"reflect"
+	"sort"
+	"sync"
+	"testing"
+)
+
+// requestedTagsConfig is a template declaring one floating alias, built for the
+// given architectures. The release tags come from the command line.
+func requestedTagsConfig(architectures ...string) Config {
+	return Config{
+		Name:          "mealie",
+		Version:       "v3.24.0",
+		Registry:      "ghcr.io/cowdogmoo",
+		Architectures: architectures,
+		Targets:       []Target{{Type: "container", Registry: "ghcr.io/cowdogmoo", Tags: []string{"stable"}}},
+	}
+}
+
+// TestPushMultiArchPublishesEveryRequestedTag pins the rule that every --tag
+// reaches the registry. The first names the release; the rest publish beside it,
+// as the target's declared tags do. Dropping them published a release under
+// fewer names than the operator asked for, with no error to say so.
+func TestPushMultiArchPublishesEveryRequestedTag(t *testing.T) {
+	var mu sync.Mutex
+	var built, pushed []string
+
+	bldr := recordingBuilder(&built, &pushed, &mu)
+	svc := NewBuildService(nil, func(_ context.Context) (ContainerBuilder, error) { return bldr, nil })
+
+	cfg := requestedTagsConfig("amd64", "arm64")
+	opts := BuildOptions{
+		Registry: "ghcr.io/cowdogmoo",
+		Push:     true,
+		Tags:     []string{"v9.9.9", "v9.9", "rc"},
+	}
+
+	results, err := svc.ExecuteContainerBuild(context.Background(), cfg, opts)
+	if err != nil {
+		t.Fatalf("ExecuteContainerBuild() error = %v", err)
+	}
+	if err := svc.Push(context.Background(), cfg, results, opts); err != nil {
+		t.Fatalf("Push() error = %v", err)
+	}
+
+	want := []string{
+		"ghcr.io/cowdogmoo/mealie:rc",
+		"ghcr.io/cowdogmoo/mealie:stable",
+		"ghcr.io/cowdogmoo/mealie:v9.9",
+		"ghcr.io/cowdogmoo/mealie:v9.9.9",
+	}
+	if got := bldr.manifestNames(); !reflect.DeepEqual(got, want) {
+		t.Errorf("manifest lists = %v, want %v", got, want)
+	}
+}
+
+// TestPushSingleArchAppliesEveryRequestedTag checks the same rule on the
+// single-architecture path, where the extra tags are applied to the image itself
+// rather than to a manifest list.
+func TestPushSingleArchAppliesEveryRequestedTag(t *testing.T) {
+	var mu sync.Mutex
+	var built, pushed []string
+
+	bldr := recordingBuilder(&built, &pushed, &mu)
+	svc := NewBuildService(nil, func(_ context.Context) (ContainerBuilder, error) { return bldr, nil })
+
+	cfg := requestedTagsConfig("amd64")
+	opts := BuildOptions{
+		Registry: "ghcr.io/cowdogmoo",
+		Push:     true,
+		Tags:     []string{"v9.9.9", "v9.9"},
+	}
+
+	results, err := svc.ExecuteContainerBuild(context.Background(), cfg, opts)
+	if err != nil {
+		t.Fatalf("ExecuteContainerBuild() error = %v", err)
+	}
+	if err := svc.Push(context.Background(), cfg, results, opts); err != nil {
+		t.Fatalf("Push() error = %v", err)
+	}
+
+	want := []string{
+		"ghcr.io/cowdogmoo/mealie:stable",
+		"ghcr.io/cowdogmoo/mealie:v9.9",
+		"ghcr.io/cowdogmoo/mealie:v9.9.9",
+	}
+
+	sort.Strings(built)
+	if !reflect.DeepEqual(built, want) {
+		t.Errorf("tagged %v, want %v", built, want)
+	}
+
+	sort.Strings(pushed)
+	if !reflect.DeepEqual(pushed, want) {
+		t.Errorf("pushed %v, want %v", pushed, want)
+	}
+}

--- a/builder/imageref.go
+++ b/builder/imageref.go
@@ -41,21 +41,36 @@ func PrimaryImageRef(cfg Config) string {
 	return ImageRef(cfg, cfg.Version)
 }
 
-// AdditionalTagRefs returns a reference for every tag the container targets
-// declare beyond the version the image already carries. Order follows the
-// template; the version itself and any repeat are dropped so no image is tagged
-// twice with the same reference.
+// AdditionalTagRefs returns a reference for every tag the image carries beyond
+// the version: first the extra tags asked for on the command line, then the ones
+// the container targets declare. The version itself and any repeat are dropped
+// so no image is tagged twice with the same reference.
 //
-// A configuration with SkipTargetTags set declares none: the per-architecture
-// images of a multi-arch build are components tagged by architecture, and the
-// template's tags name the manifest list that unites them.
+// A configuration with SkipReleaseTags set carries none of them: the
+// per-architecture images of a multi-arch build are components tagged by
+// architecture, and every release tag names the manifest list that unites them.
 func AdditionalTagRefs(cfg Config) []string {
-	if cfg.SkipTargetTags {
+	if cfg.SkipReleaseTags {
 		return nil
 	}
 
 	var refs []string
 	seen := map[string]bool{cfg.Version: true}
+
+	add := func(tag string) {
+		if tag == "" || seen[tag] {
+			return
+		}
+
+		seen[tag] = true
+		refs = append(refs, ImageRef(cfg, tag))
+	}
+
+	// Requested tags come first: they name this particular run, while the
+	// template's tags are aliases that ride along with it.
+	for _, tag := range cfg.ExtraTags {
+		add(tag)
+	}
 
 	for i := range cfg.Targets {
 		if cfg.Targets[i].Type != "container" {
@@ -63,12 +78,7 @@ func AdditionalTagRefs(cfg Config) []string {
 		}
 
 		for _, tag := range cfg.Targets[i].Tags {
-			if tag == "" || seen[tag] {
-				continue
-			}
-
-			seen[tag] = true
-			refs = append(refs, ImageRef(cfg, tag))
+			add(tag)
 		}
 	}
 

--- a/builder/imageref_test.go
+++ b/builder/imageref_test.go
@@ -134,3 +134,49 @@ func TestAdditionalTagRefs(t *testing.T) {
 		})
 	}
 }
+
+// TestAdditionalTagRefsDedupesRequestedTags checks the two tag sources merge into
+// one list of distinct references: a requested tag repeating the version, an
+// empty value, a repeat of itself, or a tag the target already declares must not
+// produce a second reference to the same image.
+func TestAdditionalTagRefsDedupesRequestedTags(t *testing.T) {
+	t.Parallel()
+
+	cfg := Config{
+		Name:      "mealie",
+		Version:   "v9.9.9",
+		Registry:  "ghcr.io/cowdogmoo",
+		ExtraTags: []string{"stable", "v9.9.9", "", "v9.9", "v9.9"},
+		Targets:   []Target{{Type: "container", Tags: []string{"stable", "latest"}}},
+	}
+
+	// Requested tags come first, then the declared ones the request did not
+	// already cover.
+	want := []string{
+		"ghcr.io/cowdogmoo/mealie:stable",
+		"ghcr.io/cowdogmoo/mealie:v9.9",
+		"ghcr.io/cowdogmoo/mealie:latest",
+	}
+	if got := AdditionalTagRefs(cfg); !reflect.DeepEqual(got, want) {
+		t.Errorf("AdditionalTagRefs() = %v, want %v", got, want)
+	}
+}
+
+// TestAdditionalTagRefsSkipsReleaseTagsForComponents checks a per-architecture
+// component build carries neither the declared tags nor the requested ones.
+func TestAdditionalTagRefsSkipsReleaseTagsForComponents(t *testing.T) {
+	t.Parallel()
+
+	cfg := Config{
+		Name:            "mealie",
+		Version:         "amd64",
+		Registry:        "ghcr.io/cowdogmoo",
+		ExtraTags:       []string{"v9.9.9"},
+		Targets:         []Target{{Type: "container", Tags: []string{"stable"}}},
+		SkipReleaseTags: true,
+	}
+
+	if got := AdditionalTagRefs(cfg); got != nil {
+		t.Errorf("AdditionalTagRefs() = %v, want none for a component build", got)
+	}
+}

--- a/builder/options.go
+++ b/builder/options.go
@@ -111,13 +111,22 @@ func ApplyOverrides(ctx context.Context, config *Config, opts BuildOptions, glob
 	applyCacheOptions(config, opts)
 }
 
-// applyTagOverride applies tag override to set the image version from CLI --tag flag
+// applyTagOverride resolves the --tag flag. The first value sets the version the
+// release is named after; the rest are published alongside it the way a
+// container target's declared tags are. The flag is a string slice, so dropping
+// everything after the first value silently published fewer tags than asked for.
 func applyTagOverride(ctx context.Context, config *Config, opts BuildOptions) {
 	if len(opts.Tags) == 0 {
 		return
 	}
+
 	config.Version = opts.Tags[0]
+	config.ExtraTags = opts.Tags[1:]
+
 	logging.DebugContext(ctx, "Overriding version with tag: %s", config.Version)
+	if len(config.ExtraTags) > 0 {
+		logging.DebugContext(ctx, "Publishing %d additional requested tag(s): %v", len(config.ExtraTags), config.ExtraTags)
+	}
 }
 
 // applyTargetTypeFilter filters targets based on the target type override

--- a/builder/orchestrator.go
+++ b/builder/orchestrator.go
@@ -81,10 +81,11 @@ func (bo *BuildOrchestrator) BuildMultiArch(ctx context.Context, requests []Buil
 			// Use architecture as tag to prevent local image overwrites
 			configCopy.Version = req.Architecture
 
-			// The template's tags name the manifest list that unites the
-			// architectures, so applying them here would have each architecture
-			// overwrite the other's tags locally and race them to the registry.
-			configCopy.SkipTargetTags = true
+			// Every release tag, requested or declared, names the manifest list
+			// that unites the architectures, so applying one here would have each
+			// architecture overwrite the other's tags locally and race them to
+			// the registry.
+			configCopy.SkipReleaseTags = true
 
 			result, err := builder.Build(ctx, configCopy)
 			if err != nil {

--- a/builder/service_test.go
+++ b/builder/service_test.go
@@ -1855,19 +1855,21 @@ func multiArchConfig() Config {
 	}
 }
 
-// TestMultiArchComponentBuildsSkipTargetTags pins the rule that a per-architecture
-// image is a build component, not a release: it is tagged by architecture, and the
-// template's tags belong on the manifest list that unites the architectures. Tagging
-// them per architecture makes each architecture overwrite the other's :latest, and
+// TestMultiArchComponentBuildsSkipEveryReleaseTag pins the rule that a
+// per-architecture image is a build component, not a release: it is tagged by
+// architecture, and every release tag — declared by the template or requested with
+// --tag — belongs on the manifest list that unites the architectures. Tagging them
+// per architecture makes each architecture overwrite the other's :latest, and
 // publishes a release tag that resolves to whichever architecture finished last.
-func TestMultiArchComponentBuildsSkipTargetTags(t *testing.T) {
+func TestMultiArchComponentBuildsSkipEveryReleaseTag(t *testing.T) {
 	var mu sync.Mutex
 	var built, pushed []string
 
 	bldr := recordingBuilder(&built, &pushed, &mu)
 	svc := NewBuildService(nil, func(_ context.Context) (ContainerBuilder, error) { return bldr, nil })
 
-	results, err := svc.ExecuteContainerBuild(context.Background(), multiArchConfig(), BuildOptions{Registry: "ghcr.io/cowdogmoo"})
+	opts := BuildOptions{Registry: "ghcr.io/cowdogmoo", Tags: []string{"v9.9.9", "v9.9"}}
+	results, err := svc.ExecuteContainerBuild(context.Background(), multiArchConfig(), opts)
 	if err != nil {
 		t.Fatalf("ExecuteContainerBuild() error = %v", err)
 	}

--- a/docs/template-reference.md
+++ b/docs/template-reference.md
@@ -345,7 +345,13 @@ declares still publish alongside it. Building a template whose `version` is
 `v1.0.0` and whose target declares `tags: [latest]` with `--tag v1.0.1`
 publishes `v1.0.1` and `latest`, and does not publish `v1.0.0`. The declared tags
 are floating aliases meant to point at whatever was built last, while `--tag`
-names this particular release. Repeating the flag applies only its first value.
+names this particular release.
+
+The flag may be repeated. The first value sets the version; every additional
+`--tag` publishes beside it exactly as a declared tag does, so
+`--tag v1.0.1 --tag v1.0` on that same template publishes `v1.0.1`, `v1.0` and
+`latest`. Requested tags are applied before declared ones, and a value repeating
+the version or another tag is published once.
 
 The image is built as the resolved version, then tagged with every entry in the
 target's `tags` list, so a single build can publish `v1.0.1` and `latest`


### PR DESCRIPTION
**Key Changes:**

- Every `--tag` value now reaches the registry instead of only the first: the first names the release version, and the rest publish alongside it exactly as a container target's declared tags do
- Renamed `SkipTargetTags` to `SkipReleaseTags` so per-architecture component builds suppress requested tags as well as declared ones, keeping every release tag on the manifest list that unites the architectures
- Merged the two tag sources into one deduplicated reference list, with requested tags applied before declared ones and repeats of the version or of another tag published once

**Added:**

- Multi-arch and single-arch coverage that every requested tag reaches the registry — `builder/extratags_test.go` asserts the manifest lists and the tag/push calls contain each `--tag` value plus the target's declared alias
- Deduplication and component-build cases in `builder/imageref_test.go` covering a requested tag repeating the version, an empty value, a self-repeat, a tag the target already declares, and a component build that carries no release tags at all

**Changed:**

- `Config` now carries `ExtraTags` for the command-line tags beyond the one that set `Version`, replacing the `SkipTargetTags` field with `SkipReleaseTags` — `builder/config.go`
- `AdditionalTagRefs` emits requested tags first, then declared ones, through a shared `add` helper that filters empty values and repeats, and returns nothing when `SkipReleaseTags` is set — `builder/imageref.go`
- `applyTagOverride` assigns `opts.Tags[1:]` to `ExtraTags` and logs the count, since silently dropping them published a release under fewer names than the operator asked for with no error to say so — `builder/options.go`
- `BuildMultiArch` sets `SkipReleaseTags` on each per-architecture config so no architecture overwrites another's tags locally or races it to the registry — `builder/orchestrator.go`
- Renamed `TestMultiArchComponentBuildsSkipTargetTags` to `TestMultiArchComponentBuildsSkipEveryReleaseTag` and passed `--tag` values into it, extending the rule to requested tags — `builder/service_test.go`
- Documented repeated `--tag` behavior, ordering, and deduplication, replacing the note that only the first value applied — `docs/template-reference.md`