### PR TITLE
test: isolate config home per test to fix flaky templates suite

### DIFF
--- a/templates/config_loader_test.go
+++ b/templates/config_loader_test.go
@@ -2724,7 +2724,7 @@ func TestPathValidatorExpandPath(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestManagerRemoveSourceNotFound(t *testing.T) {
-	t.Parallel()
+	isolateConfigHome(t)
 
 	cfg := &config.Config{}
 	cfg.Templates.LocalPaths = []string{"/path/one"}
@@ -3146,7 +3146,8 @@ func TestCreateReadmeInvalidDir(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestAddGitRepositoryValidation(t *testing.T) {
-	t.Parallel()
+	isolateConfigHome(t)
+
 	ctx := context.Background()
 
 	// Create a temporary config file for viper
@@ -3191,7 +3192,8 @@ func TestAddGitRepositoryValidation(t *testing.T) {
 }
 
 func TestAddLocalPathValidation(t *testing.T) {
-	t.Parallel()
+	isolateConfigHome(t)
+
 	ctx := context.Background()
 
 	cfg := &config.Config{}
@@ -3459,6 +3461,8 @@ func TestAddGitRepositoryAutoName(t *testing.T) {
 }
 
 func TestAddGitRepositorySameURLNoError(t *testing.T) {
+	isolateConfigHome(t)
+
 	cfg := &config.Config{
 		Templates: config.TemplatesConfig{
 			Repositories: map[string]string{
@@ -4398,6 +4402,8 @@ func TestAddLocalPathDuplicate(t *testing.T) {
 }
 
 func TestAddLocalPathNonExistent(t *testing.T) {
+	isolateConfigHome(t)
+
 	cfg := &config.Config{
 		Templates: config.TemplatesConfig{
 			LocalPaths: []string{},

--- a/templates/manager_test.go
+++ b/templates/manager_test.go
@@ -50,12 +50,9 @@ func TestNewManager(t *testing.T) {
 }
 
 func TestAddGitRepository(t *testing.T) {
+	isolateConfigHome(t)
+
 	// Skip this test if config file doesn't exist (e.g., in CI)
-	// This test requires filesystem persistence which should be an integration test
-	configPath, err := config.ConfigFile("config.yaml")
-	if err != nil || !fileExists(configPath) {
-		t.Skip("Skipping test that requires config file persistence - should be an integration test")
-	}
 
 	tests := []struct {
 		name     string
@@ -121,12 +118,9 @@ func TestAddGitRepository(t *testing.T) {
 }
 
 func TestAddLocalPath(t *testing.T) {
+	isolateConfigHome(t)
+
 	// Skip this test if config file doesn't exist (e.g., in CI)
-	// This test requires filesystem persistence which should be an integration test
-	configPath, err := config.ConfigFile("config.yaml")
-	if err != nil || !fileExists(configPath) {
-		t.Skip("Skipping test that requires config file persistence - should be an integration test")
-	}
 
 	// Create temporary directory for testing
 	tmpDir := t.TempDir()
@@ -179,12 +173,9 @@ func TestAddLocalPath(t *testing.T) {
 }
 
 func TestAddLocalPath_HomePath(t *testing.T) {
+	isolateConfigHome(t)
+
 	// Skip this test if config file doesn't exist (e.g., in CI)
-	// This test requires filesystem persistence which should be an integration test
-	configPath, err := config.ConfigFile("config.yaml")
-	if err != nil || !fileExists(configPath) {
-		t.Skip("Skipping test that requires config file persistence - should be an integration test")
-	}
 
 	// Create a temporary directory
 	tmpDir := t.TempDir()
@@ -201,19 +192,16 @@ func TestAddLocalPath_HomePath(t *testing.T) {
 	ctx := context.Background()
 
 	// Test with existing directory
-	err = manager.AddLocalPath(ctx, tmpDir)
+	err := manager.AddLocalPath(ctx, tmpDir)
 	if err != nil {
 		t.Errorf("AddLocalPath() with valid path error = %v", err)
 	}
 }
 
 func TestRemoveSource_LocalPath(t *testing.T) {
+	isolateConfigHome(t)
+
 	// Skip this test if config file doesn't exist (e.g., in CI)
-	// This test requires filesystem persistence which should be an integration test
-	configPath, err := config.ConfigFile("config.yaml")
-	if err != nil || !fileExists(configPath) {
-		t.Skip("Skipping test that requires config file persistence - should be an integration test")
-	}
 
 	tmpDir := t.TempDir()
 	anotherPath := filepath.Join(tmpDir, "another")
@@ -232,7 +220,7 @@ func TestRemoveSource_LocalPath(t *testing.T) {
 	ctx := context.Background()
 
 	// Remove existing local path
-	err = manager.RemoveSource(ctx, tmpDir)
+	err := manager.RemoveSource(ctx, tmpDir)
 	if err != nil {
 		t.Errorf("RemoveSource() error = %v", err)
 	}
@@ -244,12 +232,9 @@ func TestRemoveSource_LocalPath(t *testing.T) {
 }
 
 func TestRemoveSource_Repository(t *testing.T) {
+	isolateConfigHome(t)
+
 	// Skip this test if config file doesn't exist (e.g., in CI)
-	// This test requires filesystem persistence which should be an integration test
-	configPath, err := config.ConfigFile("config.yaml")
-	if err != nil || !fileExists(configPath) {
-		t.Skip("Skipping test that requires config file persistence - should be an integration test")
-	}
 
 	cfg := &config.Config{
 		Templates: config.TemplatesConfig{
@@ -265,7 +250,7 @@ func TestRemoveSource_Repository(t *testing.T) {
 	ctx := context.Background()
 
 	// Remove existing repository
-	err = manager.RemoveSource(ctx, "official")
+	err := manager.RemoveSource(ctx, "official")
 	if err != nil {
 		t.Errorf("RemoveSource() error = %v", err)
 	}
@@ -281,6 +266,8 @@ func TestRemoveSource_Repository(t *testing.T) {
 }
 
 func TestRemoveSource_NotFound(t *testing.T) {
+	isolateConfigHome(t)
+
 	cfg := &config.Config{
 		Templates: config.TemplatesConfig{
 			LocalPaths:   []string{},
@@ -375,7 +362,7 @@ func TestRemoveFromRepositories_NotFound(t *testing.T) {
 }
 
 func TestAddGitRepository_InvalidURL(t *testing.T) {
-	t.Parallel()
+	isolateConfigHome(t)
 
 	cfg := &config.Config{
 		Templates: config.TemplatesConfig{
@@ -395,7 +382,7 @@ func TestAddGitRepository_InvalidURL(t *testing.T) {
 }
 
 func TestAddGitRepository_PlaceholderURL(t *testing.T) {
-	t.Parallel()
+	isolateConfigHome(t)
 
 	cfg := &config.Config{
 		Templates: config.TemplatesConfig{
@@ -415,7 +402,7 @@ func TestAddGitRepository_PlaceholderURL(t *testing.T) {
 }
 
 func TestAddGitRepository_DuplicateName(t *testing.T) {
-	t.Parallel()
+	isolateConfigHome(t)
 
 	cfg := &config.Config{
 		Templates: config.TemplatesConfig{
@@ -438,7 +425,7 @@ func TestAddGitRepository_DuplicateName(t *testing.T) {
 }
 
 func TestAddGitRepository_NilRepositories(t *testing.T) {
-	t.Parallel()
+	isolateConfigHome(t)
 
 	cfg := &config.Config{
 		Templates: config.TemplatesConfig{
@@ -457,7 +444,7 @@ func TestAddGitRepository_NilRepositories(t *testing.T) {
 }
 
 func TestAddLocalPath_Expansion(t *testing.T) {
-	t.Parallel()
+	isolateConfigHome(t)
 
 	tmpDir := t.TempDir()
 
@@ -477,13 +464,7 @@ func TestAddLocalPath_Expansion(t *testing.T) {
 }
 
 func TestAddLocalPath_AlreadyExists(t *testing.T) {
-	t.Parallel()
-
-	// Skip if config file doesn't exist
-	configPath, err := config.ConfigFile("config.yaml")
-	if err != nil || !fileExists(configPath) {
-		t.Skip("Skipping test that requires config file persistence")
-	}
+	isolateConfigHome(t)
 
 	tmpDir := t.TempDir()
 
@@ -496,7 +477,7 @@ func TestAddLocalPath_AlreadyExists(t *testing.T) {
 	ctx := context.Background()
 
 	// Adding same path again should not error (warn only)
-	err = manager.AddLocalPath(ctx, tmpDir)
+	err := manager.AddLocalPath(ctx, tmpDir)
 	if err != nil {
 		t.Errorf("AddLocalPath() with duplicate path error = %v, want nil (warn only)", err)
 	}
@@ -508,13 +489,7 @@ func TestAddLocalPath_AlreadyExists(t *testing.T) {
 }
 
 func TestRemoveSource_FromLocalPaths(t *testing.T) {
-	t.Parallel()
-
-	// Skip if config file doesn't exist
-	configPath, err := config.ConfigFile("config.yaml")
-	if err != nil || !fileExists(configPath) {
-		t.Skip("Skipping test that requires config file persistence")
-	}
+	isolateConfigHome(t)
 
 	tmpDir := t.TempDir()
 	keepPath := filepath.Join(tmpDir, "keep")
@@ -531,7 +506,7 @@ func TestRemoveSource_FromLocalPaths(t *testing.T) {
 	manager := NewManager(cfg)
 	ctx := context.Background()
 
-	err = manager.RemoveSource(ctx, removePath)
+	err := manager.RemoveSource(ctx, removePath)
 	if err != nil {
 		t.Errorf("RemoveSource() error = %v", err)
 	}
@@ -545,13 +520,7 @@ func TestRemoveSource_FromLocalPaths(t *testing.T) {
 }
 
 func TestRemoveSource_FromRepos(t *testing.T) {
-	t.Parallel()
-
-	// Skip if config file doesn't exist
-	configPath, err := config.ConfigFile("config.yaml")
-	if err != nil || !fileExists(configPath) {
-		t.Skip("Skipping test that requires config file persistence")
-	}
+	isolateConfigHome(t)
 
 	cfg := &config.Config{
 		Templates: config.TemplatesConfig{
@@ -565,7 +534,7 @@ func TestRemoveSource_FromRepos(t *testing.T) {
 	manager := NewManager(cfg)
 	ctx := context.Background()
 
-	err = manager.RemoveSource(ctx, "remove")
+	err := manager.RemoveSource(ctx, "remove")
 	if err != nil {
 		t.Errorf("RemoveSource() error = %v", err)
 	}
@@ -579,7 +548,7 @@ func TestRemoveSource_FromRepos(t *testing.T) {
 }
 
 func TestRemoveSource_NotFoundEmpty(t *testing.T) {
-	t.Parallel()
+	isolateConfigHome(t)
 
 	cfg := &config.Config{
 		Templates: config.TemplatesConfig{

--- a/templates/test_helpers_test.go
+++ b/templates/test_helpers_test.go
@@ -38,6 +38,35 @@ func TestMain(m *testing.M) {
 	os.Exit(runTestMain(m))
 }
 
+// isolateConfigHome gives one test its own config home, seeded with an empty
+// config file, and returns the directory holding it.
+//
+// The package-wide home from TestMain is a single file. Manager.saveConfigValue
+// and Manager.saveTemplatesConfig read it, edit it and write it back, so two
+// tests persisting a source at the same time can read what the other left
+// half-written. That surfaces as "failed to read config: While parsing config:
+// yaml: ... could not find expected ':'".
+//
+// This mutates process-global environment, so a test that calls it must not call
+// t.Parallel(); t.Setenv panics if it does. Serialising these few tests is the
+// price of each having a config file nothing else touches.
+func isolateConfigHome(t *testing.T) string {
+	t.Helper()
+
+	configHome := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", configHome)
+
+	configDir := filepath.Join(configHome, "warpgate")
+	if err := os.MkdirAll(configDir, config.DirPermReadWriteExec); err != nil {
+		t.Fatalf("failed to create isolated config dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(configDir, "config.yaml"), nil, config.FilePermReadWrite); err != nil {
+		t.Fatalf("failed to seed isolated config file: %v", err)
+	}
+
+	return configDir
+}
+
 func runTestMain(m *testing.M) int {
 	home, err := os.MkdirTemp("", "warpgate-testhome")
 	if err != nil {
@@ -68,10 +97,32 @@ func runTestMain(m *testing.M) int {
 		fmt.Fprintf(os.Stderr, "failed to create isolated config dir: %v\n", err)
 		return 1
 	}
-	if err := os.WriteFile(filepath.Join(configDir, "config.yaml"), nil, config.FilePermReadWrite); err != nil {
+	sharedConfig := filepath.Join(configDir, "config.yaml")
+	if err := os.WriteFile(sharedConfig, nil, config.FilePermReadWrite); err != nil {
 		fmt.Fprintf(os.Stderr, "failed to seed isolated config file: %v\n", err)
 		return 1
 	}
 
-	return m.Run()
+	code := m.Run()
+	if code != 0 {
+		return code
+	}
+
+	// This one file is shared by every test in the package, so anything that
+	// writes it is racing every other writer. A test that persists a template
+	// source has to call isolateConfigHome first; the seeded file staying empty
+	// is what proves none of them skipped it.
+	info, err := os.Stat(sharedConfig)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to stat the shared config file: %v\n", err)
+		return 1
+	}
+	if info.Size() != 0 {
+		fmt.Fprintf(os.Stderr,
+			"a test wrote the package-wide config file %s (%d bytes); call isolateConfigHome(t) in every test that persists a template source\n",
+			sharedConfig, info.Size())
+		return 1
+	}
+
+	return code
 }


### PR DESCRIPTION
**Key Changes:**

- Added an `isolateConfigHome(t)` helper that gives each config-persisting test its own `XDG_CONFIG_HOME` and seeded config file, eliminating the read-modify-write race between parallel tests that produced intermittent "failed to read config: While parsing config: yaml: ... could not find expected ':'" failures
- Replaced the `t.Skip` guards that silently disabled ~8 persistence tests whenever a config file was absent (notably in CI), so those tests now actually run
- Added a post-run assertion in `TestMain` that fails the package if the shared config file is no longer empty, catching any future test that persists a source without isolating first
- Dropped `t.Parallel()` from the affected tests, since `t.Setenv` panics in parallel tests

**Added:**

- `isolateConfigHome` helper in `templates/test_helpers_test.go` - creates a per-test temp config home, points `XDG_CONFIG_HOME` at it, creates the `warpgate` directory and seeds an empty `config.yaml`, returning the config directory; documents why callers must stay non-parallel
- Shared-config guard in `runTestMain` - stats the package-wide `config.yaml` after `m.Run()` and fails with a pointed message naming the file, its size, and the required fix if any test wrote to it

**Changed:**

- Test isolation strategy across `templates/manager_test.go` and `templates/config_loader_test.go` - swapped `t.Parallel()` for `isolateConfigHome(t)` in the tests that exercise `AddGitRepository`, `AddLocalPath` and `RemoveSource`, and added the helper call to previously unguarded tests including `TestAddGitRepositorySameURLNoError`, `TestAddLocalPathNonExistent` and `TestRemoveSource_NotFound`
- Error variable declarations in `templates/manager_test.go` - converted `err = ...` to `err := ...` where removing the skip guards eliminated the earlier declaration

**Removed:**

- Config-file existence skip guards in `templates/manager_test.go` - deleted the `config.ConfigFile("config.yaml")` / `fileExists` checks and their "should be an integration test" skips from `TestAddGitRepository`, `TestAddLocalPath`, `TestAddLocalPath_HomePath`, `TestAddLocalPath_AlreadyExists`, `TestRemoveSource_LocalPath`, `TestRemoveSource_Repository`, `TestRemoveSource_FromLocalPaths` and `TestRemoveSource_FromRepos`, since per-test isolation now guarantees the file exists